### PR TITLE
Fix: allow specifying sbml model with file extension

### DIFF
--- a/@SBMLode/importSBML.m
+++ b/@SBMLode/importSBML.m
@@ -8,7 +8,7 @@ function importSBML(this,modelname)
 % Return values:
 %
 
-extension = [];
+extension = nan;
 if(exist([modelname],'file'))
     extension = '';
 else
@@ -22,7 +22,7 @@ else
     end
 end
 
-if(isempty(extension))
+if(isnan(extension))
     error([modelname ' could not be found in the matlab path!'])
 end
 


### PR DESCRIPTION
Fix: allow specifying sbml model with file extension. Otherwise there is no way for import when there is a .xml and .sbml file in the same folder.