### PR TITLE
bugfix for adjoints with user-provided initial sensitivities

### DIFF
--- a/src/amici_solver.cpp
+++ b/src/amici_solver.cpp
@@ -70,35 +70,37 @@ int Solver::setupAMI(const UserData *udata, TempData *tdata, Model *model) {
         goto freturn;
 
     if (udata->sensi >= AMICI_SENSI_ORDER_FIRST) {
-        if (udata->sensi_meth == AMICI_SENSI_FSA) {
-            if (model->nx > 0) {
+        
+        if (model->nx > 0) {
 
-                /* initialise sensitivities, this can either be user provided or
-                 * come from the model definition */
-                realtype *sx_tmp;
+            /* initialise sensitivities, this can either be user provided or
+             * come from the model definition */
+            realtype *sx_tmp;
 
-                if (!udata->sx0data) {
-                    if (model->fsx0(tdata->sx, tdata->x, tdata->dx, tdata) !=
-                        AMICI_SUCCESS)
-                        goto freturn;
-                } else {
-                    int ip;
-                    for (ip = 0; ip < udata->nplist; ip++) {
-                        sx_tmp = NV_DATA_S(tdata->sx[ip]);
-                        if (!sx_tmp)
-                            goto freturn;
-                        int ix;
-                        for (ix = 0; ix < model->nx; ix++) {
-                            sx_tmp[ix] =
-                                (realtype)udata->sx0data[ix + model->nx * ip];
-                        }
-                    }
-                }
-
-                if (model->fsdx0(tdata->sdx, tdata->x, tdata->dx, tdata) !=
+            if (!udata->sx0data) {
+                if (model->fsx0(tdata->sx, tdata->x, tdata->dx, tdata) !=
                     AMICI_SUCCESS)
                     goto freturn;
+            } else {
+                int ip;
+                for (ip = 0; ip < udata->nplist; ip++) {
+                    sx_tmp = NV_DATA_S(tdata->sx[ip]);
+                    if (!sx_tmp)
+                        goto freturn;
+                    int ix;
+                    for (ix = 0; ix < model->nx; ix++) {
+                        sx_tmp[ix] =
+                            (realtype)udata->sx0data[ix + model->nx * ip];
+                    }
+                }
+            }
 
+            if (model->fsdx0(tdata->sdx, tdata->x, tdata->dx, tdata) !=
+                AMICI_SUCCESS)
+                goto freturn;
+            
+            if (udata->sensi_meth == AMICI_SENSI_FSA) {
+                
                 /* Activate sensitivity calculations */
                 if (sensInit1(tdata->sx, tdata->sdx, udata) != AMICI_SUCCESS)
                     goto freturn;

--- a/src/amici_solver.cpp
+++ b/src/amici_solver.cpp
@@ -82,8 +82,7 @@ int Solver::setupAMI(const UserData *udata, TempData *tdata, Model *model) {
                     AMICI_SUCCESS)
                     goto freturn;
             } else {
-                int ip;
-                for (ip = 0; ip < udata->nplist; ip++) {
+                for (int ip = 0; ip < udata->nplist; ip++) {
                     sx_tmp = NV_DATA_S(tdata->sx[ip]);
                     if (!sx_tmp)
                         goto freturn;

--- a/src/amici_solver.cpp
+++ b/src/amici_solver.cpp
@@ -87,8 +87,7 @@ int Solver::setupAMI(const UserData *udata, TempData *tdata, Model *model) {
                     sx_tmp = NV_DATA_S(tdata->sx[ip]);
                     if (!sx_tmp)
                         goto freturn;
-                    int ix;
-                    for (ix = 0; ix < model->nx; ix++) {
+                    for (int ix = 0; ix < model->nx; ix++) {
                         sx_tmp[ix] =
                             (realtype)udata->sx0data[ix + model->nx * ip];
                     }

--- a/src/backwardproblem.cpp
+++ b/src/backwardproblem.cpp
@@ -105,43 +105,7 @@ int BackwardProblem::workBackwardProblem(const UserData *udata, TempData *tdata,
         }
     }
     
-    realtype *x_tmp;
-    if(udata->x0data) {
-        x_tmp = NV_DATA_S(tdata->x);
-        for (ix = 0; ix < model->nx; ix++)
-            x_tmp[ix] = (realtype)udata->x0data[ix];
-    } else {
-        status = model->fx0(tdata->x, tdata);
-        if (status != AMICI_SUCCESS)
-            return status;
-    }
-    /*
-    status = model->fx0(tdata->x, tdata);
-    if (status != AMICI_SUCCESS)
-        return status;
-     */
-    status = model->fdx0(tdata->x, tdata->dx, tdata);
-    if (status != AMICI_SUCCESS)
-        return status;
-    
     realtype *sx_tmp;
-    if(udata->sx0data) {
-        for (ip = 0; ip < rdata->nplist; ip++) {
-            sx_tmp = NV_DATA_S(tdata->sx[ip]);
-            for (ix = 0; ix < model->nx; ix++)
-                sx_tmp[ix] = (realtype)udata->sx0data[ix + model->nx * ip];
-        }
-    } else {
-        status = model->fsx0(tdata->sx, tdata->x, tdata->dx, tdata);
-        if (status != AMICI_SUCCESS)
-            return status;
-    }
-    /*
-    status = model->fsx0(tdata->sx, tdata->x, tdata->dx, tdata);
-    if (status != AMICI_SUCCESS)
-        return status;
-     */
-    
     realtype *xB_tmp = NV_DATA_S(tdata->xB);
     if (!xB_tmp)
         return AMICI_ERROR_ASA;


### PR DESCRIPTION
A little fix in the adjoint code: So far, Amici did not use initial states and sensitivities provided by the user via amioptions for adjoint senstiivity computation.
If there is no test case for this yet: I'll implement the Histone model as Amici example in two weeks, to have another test-example for  the Newton solver, preequilibration, and this.