### PR TITLE
Boost::serialization support for UserData and ReturnData 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ matrix:
             - doxygen
             - doxygen-latex
             - cppcheck
+            - libboost-serialization-dev
       env: ENABLE_GCOV_COVERAGE=TRUE
       before_install: 
         - gem install coveralls-lcov

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,7 @@ matrix:
     - os: osx
       compiler: clang
       before_install: 
-        - brew update 
-        #- rvm install ruby-2.3.3 && rvm --default use 2.3.3 # otherwise homebrew fails
+        - brew update # without this homebrew can stumble over wrong ruby version
         - brew install hdf5 cppcheck
         
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,8 @@ matrix:
     - os: osx
       compiler: clang
       before_install: 
-        - rvm install ruby-2.3.3 && rvm --default use 2.3.3 # otherwise homebrew fails
+        - brew update 
+        #- rvm install ruby-2.3.3 && rvm --default use 2.3.3 # otherwise homebrew fails
         - brew install hdf5 cppcheck
         
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,9 @@ matrix:
         - ./scripts/run-coveralls.sh
     - os: osx
       compiler: clang
-      before_install: brew install hdf5 cppcheck
+      before_install: 
+        - rvm install ruby-2.3.3 && rvm --default use 2.3.3 # otherwise homebrew fails
+        - brew install hdf5 cppcheck
         
 install:
     - ./scripts/run-build.sh

--- a/include/amici_misc.h
+++ b/include/amici_misc.h
@@ -1,16 +1,11 @@
 #ifndef AMICI_MISC_H
 #define AMICI_MISC_H
 
-#ifdef __cplusplus
-#define EXTERNC extern "C"
-#else
-#define EXTERNC
-#endif
-
-EXTERNC void zeros(double *destination, int count);
-EXTERNC void fillArray(double *destination, int count, double value);
-EXTERNC void printArray(double const *array, int numElements);
-EXTERNC void printfArray(double const *array, int numElements,
+#include<algorithm>
+void zeros(double *destination, int count);
+void fillArray(double *destination, int count, double value);
+void printArray(double const *array, int numElements);
+void printfArray(double const *array, int numElements,
                          char const *format);
 
 #endif // AMICI_MISC_H

--- a/include/amici_serialization.h
+++ b/include/amici_serialization.h
@@ -1,0 +1,207 @@
+#ifndef AMICI_SERIALIZATION_H
+#define AMICI_SERIALIZATION_H
+
+#include "include/udata.h"
+#include "include/rdata.h"
+#include <cassert>
+#include <boost/serialization/array.hpp>
+
+/* Helper functions and forward declarations for boost::serialization */
+namespace boost {
+namespace serialization {
+
+template <class Archive, typename T>
+void archiveRawArray(Archive &ar, T **p, int size) {
+    if (Archive::is_loading::value) {
+        assert(*p == nullptr); // ensure it's unset, otherwise would have to deallocate
+        ar &size;
+        *p = size ? new T[size] : nullptr;
+    } else {
+        size = *p == nullptr ? 0 : size;
+        ar &size;
+    }
+    ar &make_array<T>(*p, size);
+}
+
+template <class Archive>
+void serialize(Archive &ar, UserData &u, const unsigned int version) {
+    ar &const_cast<int &>(u.np);
+    ar &const_cast<int &>(u.nk);
+    ar &const_cast<int &>(u.nx);
+    ar &u.pscale;
+    ar &u.nmaxevent;
+    ar &u.nplist;
+    ar &u.nt;
+    ar &u.tstart;
+    ar &u.sensi;
+    ar &u.atol;
+    ar &u.rtol;
+    ar &u.maxsteps;
+    ar &u.ism;
+    ar &u.sensi_meth;
+    ar &u.linsol;
+    ar &u.interpType;
+    ar &u.lmm;
+    ar &u.iter;
+    ar &u.stldet;
+    ar &u.ordering;
+
+    archiveRawArray(ar, &u.qpositivex, u.nx);
+    archiveRawArray(ar, &u.plist, u.nplist);
+    archiveRawArray(ar, &u.p, u.np);
+    archiveRawArray(ar, &u.k, u.nk);
+    archiveRawArray(ar, &u.ts, u.nt);
+    archiveRawArray(ar, &u.pbar, u.np);
+    archiveRawArray(ar, &u.xbar, u.nx);
+    archiveRawArray(ar, &u.x0data, u.nx);
+    archiveRawArray(ar, &u.sx0data, u.np * u.nx);
+}
+
+
+template <class Archive>
+void serialize(Archive &ar, ReturnData &r, const unsigned int version) {
+    ar &r.freeFieldsOnDestruction;
+
+    ar &const_cast<int &>(r.np);
+    ar &const_cast<int &>(r.nk);
+    ar &const_cast<int &>(r.nx);
+    ar &const_cast<int &>(r.nxtrue);
+    ar &const_cast<int &>(r.ny);
+    ar &const_cast<int &>(r.nytrue);
+    ar &const_cast<int &>(r.nz);
+    ar &const_cast<int &>(r.nztrue);
+    ar &const_cast<int &>(r.ne);
+    ar &const_cast<int &>(r.nJ);
+    ar &const_cast<int &>(r.nplist);
+    ar &const_cast<int &>(r.nmaxevent);
+    ar &const_cast<int &>(r.nt);
+    ar &const_cast<int &>(r.newton_maxsteps);
+    ar &const_cast<AMICI_parameter_scaling &>(r.pscale);
+    ar &const_cast<AMICI_o2mode &>(r.o2mode);
+    ar &const_cast<AMICI_sensi_order &>(r.sensi);
+    ar &const_cast<AMICI_sensi_meth &>(r.sensi_meth);
+
+    archiveRawArray(ar, &r.ts, r.nt);
+    archiveRawArray(ar, &r.xdot, r.nx);
+    archiveRawArray(ar, &r.J, r.nx * r.nx);
+    archiveRawArray(ar, &r.z, r.nmaxevent * r.nz);
+    archiveRawArray(ar, &r.sigmaz, r.nmaxevent * r.nz);
+    archiveRawArray(ar, &r.sz, r.nmaxevent * r.nz * r.nplist);
+    archiveRawArray(ar, &r.ssigmaz, r.nmaxevent * r.nz * r.nplist);
+    archiveRawArray(ar, &r.rz, r.nmaxevent * r.nz);
+    archiveRawArray(ar, &r.srz, r.nmaxevent * r.nz * r.nplist);
+    archiveRawArray(ar, &r.s2rz, r.nmaxevent * r.nz * r.nplist * r.nplist);
+    archiveRawArray(ar, &r.x, r.nt * r.nx);
+    archiveRawArray(ar, &r.sx, r.nt * r.nx * r.nplist);
+    archiveRawArray(ar, &r.y, r.nt * r.ny);
+    archiveRawArray(ar, &r.sigmay, r.nt * r.ny);
+    archiveRawArray(ar, &r.sy, r.nt * r.ny * r.nplist);
+    archiveRawArray(ar, &r.ssigmay, r.nt * r.ny * r.nplist);
+
+    archiveRawArray(ar, &r.numsteps, r.nt);
+    archiveRawArray(ar, &r.numstepsB, r.nt);
+    archiveRawArray(ar, &r.numrhsevals, r.nt);
+    archiveRawArray(ar, &r.numrhsevalsB, r.nt);
+    archiveRawArray(ar, &r.numerrtestfails, r.nt);
+    archiveRawArray(ar, &r.numerrtestfailsB, r.nt);
+    archiveRawArray(ar, &r.numnonlinsolvconvfails, r.nt);
+    archiveRawArray(ar, &r.numnonlinsolvconvfailsB, r.nt);
+    archiveRawArray(ar, &r.order, r.nt);
+
+    archiveRawArray(ar, &r.newton_status, r.nt);
+    archiveRawArray(ar, &r.newton_time, r.nt);
+    archiveRawArray(ar, &r.newton_numsteps, r.nt);
+    archiveRawArray(ar, &r.newton_numlinsteps, r.nt);
+    archiveRawArray(ar, &r.x0, r.nx);
+    archiveRawArray(ar, &r.sx0, r.nx * r.nplist);
+
+    archiveRawArray(ar, &r.llh, 1);
+    archiveRawArray(ar, &r.chi2, 1);
+    archiveRawArray(ar, &r.sllh, r.nplist);
+    archiveRawArray(ar, &r.s2llh, r.nplist * r.nplist);
+    archiveRawArray(ar, &r.status, 1);
+}
+
+
+} // namespace serialization
+} // namespace boost
+
+#include <boost/archive/binary_iarchive.hpp>
+#include <boost/archive/binary_oarchive.hpp>
+#include <boost/archive/text_iarchive.hpp>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/iostreams/device/back_inserter.hpp>
+#include <boost/iostreams/stream.hpp>
+#include <fstream>
+#include <iostream>
+
+
+
+template <typename T>
+char *serializeToChar(const T *data, int *size) {
+    std::string serialized;
+    boost::iostreams::back_insert_device<std::string> inserter(serialized);
+    boost::iostreams::stream<boost::iostreams::back_insert_device<std::string>>
+        s(inserter);
+    boost::archive::binary_oarchive oar(s);
+    oar << *data;
+    s.flush();
+
+    char *charBuffer = new char[serialized.size()];
+    memcpy(charBuffer, serialized.data(), serialized.size());
+
+    if (size)
+        *size = serialized.size();
+
+    return charBuffer;
+}
+
+/**
+ * @brief Deserialize AMICI::UserData that has been serialized using
+ * serializeAmiciUserData
+ * @param buffer
+ * @param size
+ * @return The deserialized object
+ */
+
+template <typename T>
+T deserializeFromChar(const char *buffer, int size) {
+    boost::iostreams::basic_array_source<char> device(buffer, size);
+    boost::iostreams::stream<boost::iostreams::basic_array_source<char>> s(
+        device);
+    boost::archive::binary_iarchive iar(s);
+    T data;
+    iar >> data;
+
+    return data;
+}
+
+
+template <typename T>
+std::string serializeToString(T const& data) {
+    std::string serialized;
+    boost::iostreams::back_insert_device<std::string> inserter(serialized);
+    boost::iostreams::stream<
+        boost::iostreams::back_insert_device<std::string>>
+        s(inserter);
+    boost::archive::binary_oarchive oar(s);
+    oar << data;
+    s.flush();
+
+    return serialized;
+}
+
+template <typename T>
+T deserializeFromString(std::string const& serialized) {
+    boost::iostreams::basic_array_source<char> device(serialized.data(),
+                                                      serialized.size());
+    boost::iostreams::stream<boost::iostreams::basic_array_source<char>> s(
+        device);
+    boost::archive::binary_iarchive iar(s);
+    T deserialized;
+    iar >> deserialized;
+
+    return deserialized;
+}
+
+#endif // AMICI_SERIALIZATION_H

--- a/include/amici_serialization.h
+++ b/include/amici_serialization.h
@@ -192,6 +192,21 @@ std::string serializeToString(T const& data) {
 }
 
 template <typename T>
+std::vector<char> serializeToStdVec(const T *data) {
+    std::string serialized;
+    boost::iostreams::back_insert_device<std::string> inserter(serialized);
+    boost::iostreams::stream<boost::iostreams::back_insert_device<std::string>>
+        s(inserter);
+    boost::archive::binary_oarchive oar(s);
+    oar << *data;
+    s.flush();
+
+    std::vector<char> buf(serialized.begin(), serialized.end());
+
+    return buf;
+}
+
+template <typename T>
 T deserializeFromString(std::string const& serialized) {
     boost::iostreams::basic_array_source<char> device(serialized.data(),
                                                       serialized.size());

--- a/include/edata.h
+++ b/include/edata.h
@@ -19,9 +19,9 @@ class ExpData {
 
     ~ExpData();
 
-    /** observed data (dimension: nytrue x nt, column-major) */
+    /** observed data (dimension: nt x nytrue, column-major) */
     double *my = nullptr;
-    /** standard deviation of observed data (dimension: nytrue x nt, column-major) */
+    /** standard deviation of observed data (dimension: nt x nytrue, column-major) */
     double *sigmay = nullptr;
 
     /** observed events (dimension: nmaxevents x nztrue, column-major) */

--- a/include/edata.h
+++ b/include/edata.h
@@ -20,16 +20,17 @@ class ExpData {
 
     ~ExpData();
 
-    /** observed data */
+    /** observed data (dimension: nytrue x nt, column-major) */
     double *my = nullptr;
-    /** standard deviation of observed data */
+    /** standard deviation of observed data (dimension: nytrue x nt, column-major) */
     double *sigmay = nullptr;
 
-    /** observed events */
+    /** observed events (dimension: nmaxevents x nztrue, column-major) */
     double *mz = nullptr;
     /** observed roots */
     double *mrz = nullptr;
-    /** standard deviation of observed events/roots */
+    /** standard deviation of observed events/roots
+     * (dimension: nmaxevents x nztrue, column-major)*/
     double *sigmaz = nullptr;
     
     /** number of observables */

--- a/include/rdata.h
+++ b/include/rdata.h
@@ -220,6 +220,12 @@ class ReturnData {
     /** sensitivity method */
     const AMICI_sensi_meth sensi_meth;
 
+    /**
+     * @brief Serialize ReturnData (see boost::serialization::serialize)
+     * @param ar Archive to serialize to
+     * @param r Data to serialize
+     * @param version Version number
+     */
     template <class Archive>
     friend void boost::serialization::serialize(Archive &ar, ReturnData &r, const unsigned int version);
 };

--- a/include/rdata.h
+++ b/include/rdata.h
@@ -3,6 +3,14 @@
 #include <include/udata.h>
 
 class Model;
+class ReturnData;
+
+namespace boost {
+namespace serialization {
+template <class Archive>
+void serialize(Archive &ar, ReturnData &u, const unsigned int version);
+}}
+
 
 /** @brief struct that stores all data which is later returned by the mex
  * function
@@ -12,6 +20,8 @@ class Model;
  */
 class ReturnData {
   public:
+    ReturnData();
+
     ReturnData(const UserData *udata, const Model *model);
 
     void invalidate();
@@ -147,7 +157,6 @@ class ReturnData {
     double *status = nullptr;
 
   protected:
-    ReturnData();
 
     ReturnData(const UserData *udata, const Model *model,
                bool initializeFields);
@@ -210,6 +219,9 @@ class ReturnData {
     const AMICI_sensi_order sensi;
     /** sensitivity method */
     const AMICI_sensi_meth sensi_meth;
+
+    template <class Archive>
+    friend void boost::serialization::serialize(Archive &ar, ReturnData &r, const unsigned int version);
 };
 
 #endif /* _MY_RDATA */

--- a/include/udata.h
+++ b/include/udata.h
@@ -204,6 +204,12 @@ class UserData {
     /** number of states */
     const int nx;
 
+    /**
+     * @brief Serialize UserData (see boost::serialization::serialize)
+     * @param ar Archive to serialize to
+     * @param r Data to serialize
+     * @param version Version number
+     */
     template <class Archive>
     friend void boost::serialization::serialize(Archive &ar, UserData &r, const unsigned int version);
 

--- a/include/udata.h
+++ b/include/udata.h
@@ -4,6 +4,13 @@
 
 #include <cmath>
 
+class UserData;
+namespace boost {
+namespace serialization {
+template <class Archive>
+void serialize(Archive &ar, UserData &u, const unsigned int version);
+}}
+
 /** @brief struct that stores all user provided data
  * NOTE: multidimensional arrays are expected to be stored in column-major order
  * (FORTRAN-style)
@@ -196,6 +203,10 @@ class UserData {
     const int nk;
     /** number of states */
     const int nx;
+
+    template <class Archive>
+    friend void boost::serialization::serialize(Archive &ar, UserData &r, const unsigned int version);
+
 };
 
 #endif /* _MY_UDATA */

--- a/tests/cpputest/CMakeLists.txt
+++ b/tests/cpputest/CMakeLists.txt
@@ -14,6 +14,7 @@ set(CPPUTEST_DIR "${AMICI_DIR}/ThirdParty/cpputest-3.8/" CACHE PATH "cppUTest ro
 set(CPPUTEST_INCLUDE_DIR "${CPPUTEST_DIR}/include" CACHE PATH "cppUTest include directory")
 set(CPPUTEST_LIBRARY "${CPPUTEST_DIR}/lib/libCppUTest.a" "${CPPUTEST_DIR}/lib/libCppUTestExt.a"  CACHE PATH "cppUTest libraries")
 
+set(CMAKE_CXX_FLAGS_OLD "${CMAKE_CXX_FLAGS}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -include ${CPPUTEST_INCLUDE_DIR}/CppUTest/MemoryLeakDetectorNewMacros.h")
 
 find_package(HDF5 COMPONENTS C HL REQUIRED)

--- a/tests/cpputest/testfunctions.cpp
+++ b/tests/cpputest/testfunctions.cpp
@@ -66,6 +66,13 @@ bool withinTolerance(double expected, double actual, double atol, double rtol, i
 }
 
 void checkEqualArray(const double *expected, const double *actual, int length, double atol, double rtol) {
+    if(!expected && !actual)
+        return;
+    if(!length)
+        return;
+
+    CHECK_TRUE(expected && actual);
+
     for(int i = 0; i < length; ++i)
     {
         bool withinTol = withinTolerance(expected[i], actual[i], atol, rtol, i);
@@ -74,6 +81,11 @@ void checkEqualArray(const double *expected, const double *actual, int length, d
 }
 
 void checkEqualArrayStrided(const double *expected, const double *actual, int length, int strideExpected, int strideActual, double atol, double rtol) {
+    if(!expected && !actual)
+        return;
+
+    CHECK_TRUE(expected && actual);
+
     for(int i = 0; i < length; ++i)
     {
         bool withinTol = withinTolerance(expected[i * strideExpected], actual[i * strideActual], atol, rtol, i);

--- a/tests/cpputest/unittests/CMakeLists.txt
+++ b/tests/cpputest/unittests/CMakeLists.txt
@@ -1,10 +1,20 @@
 project(unittests)
 
+# cannot mix CppuTest new override togeter with Boost
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_OLD}")
+find_package(Boost COMPONENTS serialization)
+
+include_directories("${Boost_INCLUDE_DIR}")
+
 set(SRC_LIST
     main.cpp
     tests1.cpp
     ../testfunctions.cpp
 )
+
+if(Boost_FOUND)
+    set(SRC_LIST ${SRC_LIST} testsSerialization.cpp)
+endif()
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
@@ -12,6 +22,7 @@ add_executable(${PROJECT_NAME} ${SRC_LIST})
 
 target_link_libraries(${PROJECT_NAME}
     ${CPPUTEST_LIBRARY}
+    ${Boost_LIBRARIES}
     amici
     )
 

--- a/tests/cpputest/unittests/testsSerialization.cpp
+++ b/tests/cpputest/unittests/testsSerialization.cpp
@@ -148,6 +148,21 @@ TEST(userDataSerialization, testChar) {
     checkUserDataEqual(u, v);
 }
 
+TEST(userDataSerialization, testStdVec) {
+
+    UserData u(1, 2, 3);
+    u.p = new double[2];
+    u.p[0] = 1;
+    u.p[1] = 2;
+
+    auto buf = serializeToStdVec(&u);
+
+    UserData v = deserializeFromChar<UserData>(buf.data(), buf.size());
+
+    checkUserDataEqual(u, v);
+}
+
+
 TEST_GROUP(returnDataSerialization){void setup(){}
 
                           void teardown(){}};

--- a/tests/cpputest/unittests/testsSerialization.cpp
+++ b/tests/cpputest/unittests/testsSerialization.cpp
@@ -1,0 +1,165 @@
+
+#include <include/amici_serialization.h>
+#include "CppUTest/TestHarness.h"
+#include "CppUTestExt/MockSupport.h"
+
+#include "testfunctions.h"
+
+#include <include/amici_model.h>
+
+void checkUserDataEqual(UserData const& u, UserData const& v) {
+    CHECK_EQUAL(u.np, v.np);
+    CHECK_EQUAL(u.nx, v.nx);
+    CHECK_EQUAL(u.nk, v.nk);
+    CHECK_EQUAL(u.nx, v.nx);
+    CHECK_EQUAL(u.pscale, v.pscale);
+
+    CHECK_EQUAL(u.nmaxevent, v.nmaxevent);
+    CHECK_EQUAL(u.nplist, v.nplist);
+    CHECK_EQUAL(u.nt, v.nt);
+    CHECK_EQUAL(u.tstart, v.tstart);
+    CHECK_EQUAL(u.sensi, v.sensi);
+    CHECK_EQUAL(u.atol, v.atol);
+    CHECK_EQUAL(u.rtol, v.rtol);
+    CHECK_EQUAL(u.maxsteps, v.maxsteps);
+    CHECK_EQUAL(u.ism, v.ism);
+    CHECK_EQUAL(u.sensi_meth, v.sensi_meth);
+    CHECK_EQUAL(u.linsol, v.linsol);
+    CHECK_EQUAL(u.interpType, v.interpType);
+    CHECK_EQUAL(u.lmm, v.lmm);
+    CHECK_EQUAL(u.iter, v.iter);
+    CHECK_EQUAL(u.stldet, v.stldet);
+    CHECK_EQUAL(u.ordering, v.ordering);
+
+    checkEqualArray(u.p, v.p, u.np, 1e-16, 1e-16);
+    checkEqualArray(u.k, v.k, u.nk, 1e-16, 1e-16);
+}
+
+
+void checkReturnDataEqual(ReturnData const& r, ReturnData const& s) {
+    CHECK_EQUAL(r.np, s.np);
+    CHECK_EQUAL(r.nk, s.nk);
+    CHECK_EQUAL(r.nx, s.nx);
+    CHECK_EQUAL(r.nxtrue, s.nxtrue);
+    CHECK_EQUAL(r.ny, s.ny);
+    CHECK_EQUAL(r.nytrue, s.nytrue);
+    CHECK_EQUAL(r.nz, s.nz);
+    CHECK_EQUAL(r.nztrue, s.nztrue);
+    CHECK_EQUAL(r.ne, s.ne);
+    CHECK_EQUAL(r.nJ, s.nJ);
+    CHECK_EQUAL(r.nplist, s.nplist);
+    CHECK_EQUAL(r.nmaxevent, s.nmaxevent);
+    CHECK_EQUAL(r.nt, s.nt);
+    CHECK_EQUAL(r.newton_maxsteps, s.newton_maxsteps);
+    CHECK_EQUAL(r.pscale, s.pscale);
+    CHECK_EQUAL(r.o2mode, s.o2mode);
+    CHECK_EQUAL(r.sensi, s.sensi);
+    CHECK_EQUAL(r.sensi_meth, s.sensi_meth);
+
+    checkEqualArray(r.ts, s.ts, r.nt, 1e-16, 1e-16);
+    checkEqualArray(r.xdot, s.xdot, r.nx, 1e-16, 1e-16);
+    checkEqualArray(r.J, s.J, r.nx * r.nx, 1e-16, 1e-16);
+    checkEqualArray(r.z, s.z, r.nmaxevent * r.nz, 1e-16, 1e-16);
+    checkEqualArray(r.sigmaz, s.sigmaz, r.nmaxevent * r.nz, 1e-16, 1e-16);
+    checkEqualArray(r.sz, s.sz, r.nmaxevent * r.nz * r.nplist, 1e-16, 1e-16);
+    checkEqualArray(r.ssigmaz, s.sigmaz, r.nmaxevent * r.nz * r.nplist, 1e-16, 1e-16);
+    checkEqualArray(r.rz, s.rz, r.nmaxevent * r.nz, 1e-16, 1e-16);
+    checkEqualArray(r.srz, s.srz, r.nmaxevent * r.nz * r.nplist, 1e-16, 1e-16);
+    checkEqualArray(r.s2rz, s.s2rz, r.nmaxevent * r.nz * r.nplist * r.nplist, 1e-16, 1e-16);
+    checkEqualArray(r.ssigmaz, s.sigmaz, r.nmaxevent * r.nz * r.nplist, 1e-16, 1e-16);
+    checkEqualArray(r.x, s.x, r.nt * r.nx, 1e-16, 1e-16);
+    checkEqualArray(r.sx, s.sx, r.nt * r.nx * r.nplist, 1e-16, 1e-16);
+
+    checkEqualArray(r.y, s.y, r.nt * r.ny, 1e-16, 1e-16);
+    checkEqualArray(r.sigmay, s.sigmay, r.nt * r.ny * r.nplist, 1e-16, 1e-16);
+    checkEqualArray(r.sy, s.sy, r.nt * r.ny * r.nplist, 1e-16, 1e-16);
+    checkEqualArray(r.ssigmay, s.ssigmay, r.nt * r.ny * r.nplist, 1e-16, 1e-16);
+
+    checkEqualArray(r.numsteps, s.numsteps, r.nt, 1e-16, 1e-16);
+    checkEqualArray(r.numstepsB, s.numstepsB, r.nt, 1e-16, 1e-16);
+    checkEqualArray(r.numrhsevals, s.numrhsevals, r.nt, 1e-16, 1e-16);
+    checkEqualArray(r.numrhsevalsB, s.numrhsevalsB, r.nt, 1e-16, 1e-16);
+    checkEqualArray(r.numerrtestfails, s.numerrtestfails, r.nt, 1e-16, 1e-16);
+    checkEqualArray(r.numerrtestfailsB, s.numerrtestfailsB, r.nt, 1e-16, 1e-16);
+    checkEqualArray(r.numnonlinsolvconvfails, s.numnonlinsolvconvfails, r.nt, 1e-16, 1e-16);
+    checkEqualArray(r.numnonlinsolvconvfailsB, s.numnonlinsolvconvfailsB, r.nt, 1e-16, 1e-16);
+    checkEqualArray(r.order, s.order, r.nt, 1e-16, 1e-16);
+
+    checkEqualArray(r.newton_status, s.newton_status, r.nt, 1e-16, 1e-16);
+    checkEqualArray(r.newton_time, s.newton_time, r.nt, 1e-16, 1e-16);
+    checkEqualArray(r.newton_numsteps, s.newton_numsteps, r.nt, 1e-16, 1e-16);
+    checkEqualArray(r.newton_numlinsteps, s.newton_numlinsteps, r.nt, 1e-16, 1e-16);
+    checkEqualArray(r.x0, s.x0, r.nx, 1e-16, 1e-16);
+    checkEqualArray(r.sx0, s.sx0, r.nx * r.nplist, 1e-16, 1e-16);
+
+    CHECK_EQUAL(*r.llh, *s.llh);
+    CHECK_EQUAL(*r.chi2, *s.chi2);
+    CHECK_EQUAL(*r.status, *s.status);
+
+    checkEqualArray(r.sllh, s.sllh, r.nplist, 1e-16, 1e-16);
+    checkEqualArray(r.s2llh, s.s2llh, r.nplist * r.nplist, 1e-16, 1e-16);
+}
+
+
+TEST_GROUP(userDataSerialization){void setup(){}
+
+                          void teardown(){}};
+
+
+TEST(userDataSerialization, testFile) {
+
+    UserData u(1, 2, 3);
+    {
+        std::ofstream ofs("sstore.dat");
+        boost::archive::text_oarchive oar(ofs);
+        oar &u;
+    }
+    {
+        std::ifstream ifs("sstore.dat");
+        boost::archive::text_iarchive iar(ifs);
+        UserData v;
+        iar &v;
+        checkUserDataEqual(u, v);
+    }
+}
+
+TEST(userDataSerialization, testString) {
+
+    UserData u(1, 2, 3);
+
+    std::string serialized = serializeToString(u);
+
+    checkUserDataEqual(u, deserializeFromString<UserData>(serialized));
+}
+
+TEST(userDataSerialization, testChar) {
+
+    UserData u(1, 2, 3);
+    u.p = new double[2];
+    u.p[0] = 1;
+    u.p[1] = 2;
+
+    int length;
+    char *buf = serializeToChar(&u, &length);
+
+    UserData v = deserializeFromChar<UserData>(buf, length);
+
+    delete[] buf;
+    checkUserDataEqual(u, v);
+}
+
+TEST_GROUP(returnDataSerialization){void setup(){}
+
+                          void teardown(){}};
+
+TEST(returnDataSerialization, testString) {
+    UserData u(1, 2, 3);
+    Model m(1, 2, 3, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, AMICI_O2MODE_NONE);
+
+    ReturnData r(&u, &m);
+
+    std::string serialized = serializeToString(r);
+
+    checkReturnDataEqual(r, deserializeFromString<ReturnData>(serialized));
+}
+


### PR DESCRIPTION
Boost::serialization support for UserData and ReturnData and corresponding tests. Allows saving those data in various formats. Not relevant for use with Matlab. 