### PR TITLE
Remove const where 'type qualifier on return type is meaningless'

### DIFF
--- a/include/amici_model.h
+++ b/include/amici_model.h
@@ -399,19 +399,19 @@ namespace amici {
         /** number of paramaeters wrt to which sensitivities are computed
          * @return length of sensitivity index vector
          */
-        const int nplist() const {
+        int nplist() const {
             return plist_.size();
         }
         /** total number of model parameters
          * @return length of parameter vector
          */
-        const int np() const {
+        int np() const {
             return originalParameters.size();
         }
         /** number of constants
          * @return length of constant vector
          */
-        const int nk() const {
+        int nk() const {
             return fixedParameters.size();
         }
 
@@ -647,7 +647,7 @@ namespace amici {
           * @param pos index
           * @return entry
           */
-        const int plist(int pos) const{
+        int plist(int pos) const{
             return plist_.at(pos);
         }
 
@@ -1243,7 +1243,7 @@ namespace amici {
         
         void getsx(const int it, const ReturnData *rdata);
         
-        const realtype gett(const int it, const ReturnData *rdata) const;
+        realtype gett(const int it, const ReturnData *rdata) const;
         
         void getmz(const int nroots, const ExpData *edata);
         

--- a/include/amici_vector.h
+++ b/include/amici_vector.h
@@ -25,7 +25,7 @@ namespace amici {
          */
         AmiVector(const long int length) : vec(length,0.0) {
             nvec = N_VMake_Serial(length,vec.data());
-        };
+        }
         
         /** constructor from vector, copies data from vector
          * and constructs an nvec that points to the data
@@ -35,7 +35,7 @@ namespace amici {
         AmiVector(std::vector<realtype> rvec) {
             vec = rvec;
             nvec = N_VMake_Serial(rvec.size(),rvec.data());
-        };
+        }
         
         /** copy constructor
          * @param vold vector from which the data will be copied
@@ -43,7 +43,7 @@ namespace amici {
         AmiVector(const AmiVector& vold) {
             vec = vold.vec;
             nvec = N_VMake_Serial(vold.vec.size(),vec.data());
-        };
+        }
         
         /** copy-move assignment operator
          * @param other right hand side
@@ -55,7 +55,7 @@ namespace amici {
                 N_VDestroy_Serial(nvec);
             nvec = N_VMake_Serial(vec.size(),vec.data());
             return *this;
-        };
+        }
         
         /** data accessor
          * @return pointer to data array
@@ -81,7 +81,7 @@ namespace amici {
         /** returns the length of the vector
          * @return length
          */
-        const int getLength() const {
+        int getLength() const {
             return vec.size();
         }
         
@@ -128,7 +128,7 @@ namespace amici {
          */
         ~AmiVector(){
             N_VDestroy_Serial(nvec);
-        };
+        }
     private:
         /** main data storage
          */
@@ -161,7 +161,7 @@ namespace amici {
             for (int idx = 0; idx < length_outer; idx++) {
                 nvec_array[idx] = vec_array.at(idx).getNVector();
             }
-        };
+        }
         
         /** copy constructor
          * @param vaold object to copy from
@@ -233,7 +233,7 @@ namespace amici {
         /** length of AmiVectorArray
          * @return length
          */
-        const int getLength() const {
+        int getLength() const {
             return vec_array.size();
         }
         

--- a/src/amici_model.cpp
+++ b/src/amici_model.cpp
@@ -869,7 +869,7 @@ void Model::getsx(const int it, const ReturnData *rdata) {
      * @param rdata pointer to return data instance
      * @return current timepoint
      */
-const realtype Model::gett(const int it, const ReturnData *rdata) const {
+realtype Model::gett(const int it, const ReturnData *rdata) const {
     return static_cast<realtype>(rdata->ts[it]);
 }
 


### PR DESCRIPTION
To prevent compiler warnings (Intel)