### PR TITLE
Hotfix 266

### DIFF
--- a/src/amici_solver.cpp
+++ b/src/amici_solver.cpp
@@ -22,6 +22,12 @@ namespace amici {
  * @param model pointer to the model object
  */
 void Solver::setupAMI(ForwardProblem *fwd, Model *model) {
+    if (ami_mem) {
+        /* This solver was used before. Not sure what we need to do to reuse the allocated
+         *  memory, so just free here and then reallocate. */
+        AMIFree();
+    }
+
     model->initialize(fwd->getStatePointer(), fwd->getStateDerivativePointer());
 
     /* Create solver memory object */

--- a/tests/cpputest/steadystate/tests1.cpp
+++ b/tests/cpputest/steadystate/tests1.cpp
@@ -43,6 +43,19 @@ TEST(groupSteadystate, testCloneModel) {
 }
 
 
+TEST(groupSteadystate, testReuseSolver) {
+    auto model = getModel();
+    auto solver = model->getSolver();
+
+    amici::readModelDataFromHDF5(HDFFILE, *model, "/model_steadystate/nosensi/options");
+    amici::readSolverSettingsFromHDF5(HDFFILE, *solver, "/model_steadystate/nosensi/options");
+
+    std::unique_ptr<amici::ReturnData>(amici::getSimulationResults(*model, nullptr, *solver));
+    std::unique_ptr<amici::ReturnData>(amici::getSimulationResults(*model, nullptr, *solver));
+}
+
+
+
 TEST(groupSteadystate, testSimulation) {
     amici::simulateAndVerifyFromFile("/model_steadystate/nosensi/");
     amici::simulateAndWriteToFile("/model_steadystate/nosensi/");


### PR DESCRIPTION
Fix memory leak when the same Solver instance is used for multiple solves and add test case for the future. Fixes #266.