### PR TITLE
added check for ny > 0, due to simulation failure

### DIFF
--- a/src/forwardproblem.cpp
+++ b/src/forwardproblem.cpp
@@ -496,21 +496,17 @@ void ForwardProblem::getDataOutput(int it) {
      * @param[in] it index of current timepoint @type int
      */
     
-    if (model->ny > 0) {
-        model->fy(it, rdata);
-        model->fsigmay(it, rdata, edata);
-        model->fJy(it, rdata, edata);
-        model->fres(it, rdata, edata);
-        model->fchi2(it, rdata);
-    }
+    model->fy(it, rdata);
+    model->fsigmay(it, rdata, edata);
+    model->fJy(it, rdata, edata);
+    model->fres(it, rdata, edata);
+    model->fchi2(it, rdata);
     
     if (rdata->sensi >= AMICI_SENSI_ORDER_FIRST && model->nplist() > 0) {
-        if (model->ny > 0)
-            prepDataSensis(it);
+        prepDataSensis(it);
         
         if (rdata->sensi_meth == AMICI_SENSI_FSA) {
             getDataSensisFSA(it);
-        }
     }
 }
 
@@ -556,13 +552,11 @@ void ForwardProblem::getDataSensisFSA(int it) {
     
     model->fdsigmaydp(it, rdata, edata);
 
-    if (model->ny > 0) {
-        model->fsy(it, rdata);
-        if (edata) {
-            model->fsJy(it, dJydx, rdata);
-            model->fsres(it, rdata, edata);
-            model->fFIM(it, rdata);
-        }
+    model->fsy(it, rdata);
+    if (edata) {
+        model->fsJy(it, dJydx, rdata);
+        model->fsres(it, rdata, edata);
+        model->fFIM(it, rdata);
     }
 }
 

--- a/src/forwardproblem.cpp
+++ b/src/forwardproblem.cpp
@@ -495,15 +495,19 @@ void ForwardProblem::getDataOutput(int it) {
      *
      * @param[in] it index of current timepoint @type int
      */
-
-    model->fy(it, rdata);
-    model->fsigmay(it, rdata, edata);
-    model->fJy(it, rdata, edata);
-    model->fres(it, rdata, edata);
-    model->fchi2(it, rdata);
+    
+    if (model->ny > 0) {
+        model->fy(it, rdata);
+        model->fsigmay(it, rdata, edata);
+        model->fJy(it, rdata, edata);
+        model->fres(it, rdata, edata);
+        model->fchi2(it, rdata);
+    }
     
     if (rdata->sensi >= AMICI_SENSI_ORDER_FIRST && model->nplist() > 0) {
-        prepDataSensis(it);
+        if (model->ny > 0)
+            prepDataSensis(it);
+        
         if (rdata->sensi_meth == AMICI_SENSI_FSA) {
             getDataSensisFSA(it);
         }

--- a/src/forwardproblem.cpp
+++ b/src/forwardproblem.cpp
@@ -495,7 +495,7 @@ void ForwardProblem::getDataOutput(int it) {
      *
      * @param[in] it index of current timepoint @type int
      */
-    
+
     model->fy(it, rdata);
     model->fsigmay(it, rdata, edata);
     model->fJy(it, rdata, edata);
@@ -504,8 +504,7 @@ void ForwardProblem::getDataOutput(int it) {
     
     if (rdata->sensi >= AMICI_SENSI_ORDER_FIRST && model->nplist() > 0) {
         prepDataSensis(it);
-        
-        if (rdata->sensi_meth == AMICI_SENSI_FSA) {
+        if (rdata->sensi_meth == AMICI_SENSI_FSA)
             getDataSensisFSA(it);
     }
 }

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -13,7 +13,7 @@ namespace amici {
  * @param rdata pointer to return data instance
  */
 void Model::fsy(const int it, ReturnData *rdata) {
-    if (ny<1)
+    if (!ny)
         return;
     
     // copy dydp for current time to sy
@@ -49,7 +49,7 @@ void Model::fsz_tf(const int *nroots, const int ie, ReturnData *rdata) {
  * @param rdata pointer to return data instance
  */
 void Model::fsJy(const int it, const std::vector<realtype>& dJydx, ReturnData *rdata) {
-    
+
     // Compute dJydx*sx for current 'it'
     // dJydx        rdata->nt x nJ x nx
     // sx           rdata->nt x nx x nplist()
@@ -116,7 +116,7 @@ void Model::fdJydp(const int it, const ExpData *edata,
     if (rdata->sensi_meth != AMICI_SENSI_ASA)
         return;
 
-    if(ny < 1)
+    if(!ny)
         return;
 
     for (int iJ = 0; iJ < nJ; iJ++) {
@@ -639,8 +639,10 @@ void Model::fstau(const realtype t, const int ie, const AmiVector *x, const AmiV
   * @param rdata pointer to return data instance
   */
 void Model::fy(int it, ReturnData *rdata) {
-    if (ny>0)
-        fy(&rdata->y.at(it*ny),rdata->ts.at(it),getx(it,rdata), unscaledParameters.data(),fixedParameters.data(),h.data());
+    if (!ny)
+        return;
+    
+    fy(&rdata->y.at(it*ny),rdata->ts.at(it),getx(it,rdata), unscaledParameters.data(),fixedParameters.data(),h.data());
 }
 
 /** partial derivative of observables y w.r.t. model parameters p
@@ -648,7 +650,7 @@ void Model::fy(int it, ReturnData *rdata) {
      * @param rdata pointer to return data instance
      */
 void Model::fdydp(const int it, ReturnData *rdata) {
-    if (ny<1)
+    if (!ny)
         return;
     
     std::fill(dydp.begin(),dydp.end(),0.0);
@@ -670,7 +672,7 @@ void Model::fdydp(const int it, ReturnData *rdata) {
      * @param rdata pointer to return data instance
      */
 void Model::fdydx(const int it, ReturnData *rdata) {
-    if (ny<1)
+    if (!ny)
         return;
     
     std::fill(dydx.begin(),dydx.end(),0.0);
@@ -838,7 +840,7 @@ void Model::fdeltaqB(const int ie, const realtype t, const AmiVector *x, const A
      * @param rdata pointer to return data instance
      */
 void Model::fsigmay(const int it, ReturnData *rdata, const ExpData *edata) {
-    if (ny<1)
+    if (!ny)
         return;
     
     std::fill(sigmay.begin(),sigmay.end(),0.0);
@@ -862,7 +864,7 @@ void Model::fsigmay(const int it, ReturnData *rdata, const ExpData *edata) {
      * @param edata pointer to ExpData data instance holding sigma values
      */
 void Model::fdsigmaydp(const int it, ReturnData *rdata, const ExpData *edata) {
-    if (ny<1)
+    if (!ny)
         return;
     
     std::fill(dsigmaydp.begin(), dsigmaydp.end(), 0.0);

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -49,9 +49,6 @@ void Model::fsz_tf(const int *nroots, const int ie, ReturnData *rdata) {
  * @param rdata pointer to return data instance
  */
 void Model::fsJy(const int it, const std::vector<realtype>& dJydx, ReturnData *rdata) {
-
-    if (ny < 1)
-        reutrn;
     
     // Compute dJydx*sx for current 'it'
     // dJydx        rdata->nt x nJ x nx
@@ -62,12 +59,12 @@ void Model::fsJy(const int it, const std::vector<realtype>& dJydx, ReturnData *r
     amici_dgemm(AMICI_BLAS_ColMajor, AMICI_BLAS_NoTrans, AMICI_BLAS_NoTrans, nJ,
                 nplist(), nx, 1.0, &dJydx.at(it*nJ*nx), nJ, getsx(it,rdata), nx, 0.0,
                 multResult.data(), nJ);
-    
+
     // multResult    nJ x nplist()
     // dJydp         nJ x nplist()
     // dJydxTmp      nJ x nx
     // sxTmp         nx x nplist()
-    
+
     // sJy += multResult + dJydp
     for (int iJ = 0; iJ < nJ; ++iJ) {
         if (iJ == 0)
@@ -76,7 +73,7 @@ void Model::fsJy(const int it, const std::vector<realtype>& dJydx, ReturnData *r
         else
             for (int ip = 0; ip < nplist(); ++ip)
                 rdata->s2llh.at((iJ - 1) + ip * (nJ - 1)) -=
-                multResult.at(iJ + ip * nJ) + dJydp.at(iJ + ip * nJ);
+                        multResult.at(iJ + ip * nJ) + dJydp.at(iJ + ip * nJ);
     }
 }
 

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -13,6 +13,9 @@ namespace amici {
  * @param rdata pointer to return data instance
  */
 void Model::fsy(const int it, ReturnData *rdata) {
+    if (ny<1)
+        return;
+    
     // copy dydp for current time to sy
     std::copy(dydp.begin(), dydp.end(), &rdata->sy[it * nplist() * ny]);
 
@@ -47,6 +50,9 @@ void Model::fsz_tf(const int *nroots, const int ie, ReturnData *rdata) {
  */
 void Model::fsJy(const int it, const std::vector<realtype>& dJydx, ReturnData *rdata) {
 
+    if (ny < 1)
+        reutrn;
+    
     // Compute dJydx*sx for current 'it'
     // dJydx        rdata->nt x nJ x nx
     // sx           rdata->nt x nx x nplist()
@@ -56,12 +62,12 @@ void Model::fsJy(const int it, const std::vector<realtype>& dJydx, ReturnData *r
     amici_dgemm(AMICI_BLAS_ColMajor, AMICI_BLAS_NoTrans, AMICI_BLAS_NoTrans, nJ,
                 nplist(), nx, 1.0, &dJydx.at(it*nJ*nx), nJ, getsx(it,rdata), nx, 0.0,
                 multResult.data(), nJ);
-
+    
     // multResult    nJ x nplist()
     // dJydp         nJ x nplist()
     // dJydxTmp      nJ x nx
     // sxTmp         nx x nplist()
-
+    
     // sJy += multResult + dJydp
     for (int iJ = 0; iJ < nJ; ++iJ) {
         if (iJ == 0)
@@ -70,7 +76,7 @@ void Model::fsJy(const int it, const std::vector<realtype>& dJydx, ReturnData *r
         else
             for (int ip = 0; ip < nplist(); ++ip)
                 rdata->s2llh.at((iJ - 1) + ip * (nJ - 1)) -=
-                        multResult.at(iJ + ip * nJ) + dJydp.at(iJ + ip * nJ);
+                multResult.at(iJ + ip * nJ) + dJydp.at(iJ + ip * nJ);
     }
 }
 
@@ -636,7 +642,8 @@ void Model::fstau(const realtype t, const int ie, const AmiVector *x, const AmiV
   * @param rdata pointer to return data instance
   */
 void Model::fy(int it, ReturnData *rdata) {
-    fy(&rdata->y.at(it*ny),rdata->ts.at(it),getx(it,rdata), unscaledParameters.data(),fixedParameters.data(),h.data());
+    if (ny>0)
+        fy(&rdata->y.at(it*ny),rdata->ts.at(it),getx(it,rdata), unscaledParameters.data(),fixedParameters.data(),h.data());
 }
 
 /** partial derivative of observables y w.r.t. model parameters p
@@ -644,6 +651,9 @@ void Model::fy(int it, ReturnData *rdata) {
      * @param rdata pointer to return data instance
      */
 void Model::fdydp(const int it, ReturnData *rdata) {
+    if (ny<1)
+        return;
+    
     std::fill(dydp.begin(),dydp.end(),0.0);
 
     for(int ip = 0; (unsigned)ip < plist_.size(); ip++){
@@ -663,6 +673,9 @@ void Model::fdydp(const int it, ReturnData *rdata) {
      * @param rdata pointer to return data instance
      */
 void Model::fdydx(const int it, ReturnData *rdata) {
+    if (ny<1)
+        return;
+    
     std::fill(dydx.begin(),dydx.end(),0.0);
     fdydx(dydx.data(),rdata->ts.at(it),getx(it,rdata), unscaledParameters.data(),fixedParameters.data(),h.data());
 }
@@ -828,6 +841,9 @@ void Model::fdeltaqB(const int ie, const realtype t, const AmiVector *x, const A
      * @param rdata pointer to return data instance
      */
 void Model::fsigmay(const int it, ReturnData *rdata, const ExpData *edata) {
+    if (ny<1)
+        return;
+    
     std::fill(sigmay.begin(),sigmay.end(),0.0);
     fsigmay(sigmay.data(),rdata->ts.at(it), unscaledParameters.data(),fixedParameters.data());
     for (int iytrue = 0; iytrue < nytrue; iytrue++) {
@@ -849,6 +865,9 @@ void Model::fsigmay(const int it, ReturnData *rdata, const ExpData *edata) {
      * @param edata pointer to ExpData data instance holding sigma values
      */
 void Model::fdsigmaydp(const int it, ReturnData *rdata, const ExpData *edata) {
+    if (ny<1)
+        return;
+    
     std::fill(dsigmaydp.begin(), dsigmaydp.end(), 0.0);
 
     for(int ip = 0; (unsigned)ip < plist_.size(); ip++)


### PR DESCRIPTION
Currently, the routines fy, fJy, etc. are called in forward simulation, regardless if model->ny > 0 or not. This leads to simulation failure, if model->ny == 0.
This commit should fix the problem.