### PR TITLE
Release 0.7.7

### DIFF
--- a/python/sdist/setup.py
+++ b/python/sdist/setup.py
@@ -251,7 +251,7 @@ with open("README.md", "r") as fh:
 
 
 def getPackageVersion():
-    return '0.7.5.post1'
+    return '0.7.7'
 
 
 # Remove the "-Wstrict-prototypes" compiler option, which isn't valid for


### PR DESCRIPTION
Let's keep version numbers in the repository in sync with the release versions.