### PR TITLE
Fix Critical Bug in ExpData construction from DataFrames

### DIFF
--- a/python/amici/pandas.py
+++ b/python/amici/pandas.py
@@ -347,11 +347,20 @@ def constructEdataFromDataFrame(df, model, condition):
             overwrite_preeq.keys()]):
         edata.fixedParametersPreequilibration = \
             _get_specialized_fixed_parameters(model, condition,overwrite_preeq)
+    elif len(overwrite_preeq.keys()):
+        edata.fixedParametersPreequilibration = copy.deepcopy(
+            edata.fixedParameters
+        )
+
 
     if any([overwrite_presim[key] != condition[key] for key in
             overwrite_presim.keys()]):
         edata.fixedParametersPresimulation = _get_specialized_fixed_parameters(
             model, condition,overwrite_presim
+        )
+    elif len(overwrite_presim.keys()):
+        edata.fixedParametersPresimulation = copy.deepcopy(
+            edata.fixedParameters
         )
 
     if 't_presim' in condition.keys():

--- a/tests/testCoverage.py
+++ b/tests/testCoverage.py
@@ -11,6 +11,7 @@ import sys
 
 import testModels
 import testSBML
+import testPandas
 
 # only consider amici module and ignore the swig generated amici.py
 cov = coverage.Coverage(source=['amici'],omit=['*/amici.py','*/amici_without_hdf5.py'])
@@ -23,6 +24,7 @@ cov.start()
 suite = unittest.TestSuite()
 suite.addTest(testSBML.TestAmiciSBMLModel())
 suite.addTest(testModels.TestAmiciPregeneratedModel())
+suite.addTest(testPandas.TestAmiciPandasImportExport())
 testRunner = unittest.TextTestRunner(verbosity=0)
 result = testRunner.run(suite)
 

--- a/tests/testPandas.py
+++ b/tests/testPandas.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+
+import sys
+import amici
+import unittest
+import os
+import numpy as np
+import itertools
+
+class TestAmiciPandasImportExport(unittest.TestCase):
+    '''
+    TestCase class for testing csv import using pandas
+    '''
+
+    def setUp(self):
+        self.resetdir = os.getcwd()
+        if os.path.dirname(__file__) != '':
+            os.chdir(os.path.dirname(__file__))
+
+        sbmlFile = os.path.join(os.path.dirname(__file__), '..', 'python',
+                                'examples', 'example_presimulation',
+                                'model_presimulation.xml')
+
+        sbmlImporter = amici.SbmlImporter(sbmlFile)
+
+        constantParameters = ['DRUG_0', 'KIN_0']
+
+        observables = amici.assignmentRules2observables(
+            sbmlImporter.sbml,  # the libsbml model object
+            filter_function=lambda variable: variable.getName() == 'pPROT'
+        )
+        outdir = 'test_model_presimulation'
+        sbmlImporter.sbml2amici('test_model_presimulation',
+                                outdir,
+                                verbose=False,
+                                observables=observables,
+                                constantParameters=constantParameters)
+        sys.path.insert(0, outdir)
+        import test_model_presimulation as modelModule
+        self.model = modelModule.getModel()
+        self.model.setTimepoints(np.linspace(0, 60, 61))
+        self.solver = self.model.getSolver()
+        rdata = amici.runAmiciSimulation(self.model, self.solver)
+        self.edata = [amici.ExpData(rdata, 0.01, 0)]
+
+    def tearDown(self):
+        os.chdir(self.resetdir)
+
+    def runTest(self):
+        self.tests_presimulation()
+
+    def tests_presimulation(self):
+        self.model.getFixedParameterNames()
+        combos = itertools.product(
+            [(10, 5), (5, 10), ()],
+            repeat=3
+        )
+        cases = dict()
+        for icombo, combo in enumerate(combos):
+            cases[f'{icombo}'] = {
+                'fixedParameters': combo[0],
+                'fixedParametersPreequilibration': combo[1],
+                'fixedParametersPresimulation': combo[2],
+            }
+
+        for case in cases:
+            with self.subTest(**cases[case]):
+                for fp in cases[case]:
+                    setattr(self.edata[0], fp, cases[case][fp])
+
+                df_edata = amici.getDataObservablesAsDataFrame(
+                    self.model,
+                    self.edata
+                )
+                edata_reconstructed = amici.getEdataFromDataFrame(
+                    self.model,
+                    df_edata
+                )
+
+                for fp in ['fixedParameters', 'fixedParametersPreequilibration',
+                           'fixedParametersPresimulation']:
+
+                    if fp != 'fixedParameters' or cases[case][fp] is not ():
+                        self.assertTupleEqual(
+                            getattr(self.edata[0], fp),
+                            getattr(edata_reconstructed[0], fp),
+                        )
+
+                        self.assertTupleEqual(
+                            cases[case][fp],
+                            getattr(edata_reconstructed[0], fp),
+                        )
+
+                        self.assertTupleEqual(
+                            getattr(self.edata[0], fp),
+                            cases[case][fp],
+                        )
+                    else:
+                        self.assertTupleEqual(
+                            self.model.getFixedParameters(),
+                            getattr(edata_reconstructed[0], fp),
+                        )
+
+                        self.assertTupleEqual(
+                            self.model.getFixedParameters(),
+                            getattr(edata_reconstructed[0], fp),
+                        )
+
+                        self.assertTupleEqual(
+                            getattr(self.edata[0], fp),
+                            cases[case][fp],
+                        )
+
+
+
+if __name__ == '__main__':
+    suite = unittest.TestSuite()
+    suite.addTest(TestAmiciPandasImportExport())
+    unittest.main()
+    


### PR DESCRIPTION
Previously, `edata.fixedParametersPreequilibration` or `edata.fixedParametersPresimulation` were not set if they were the same as `edata.fixedParameters` ...