### PR TITLE
fix(matlab) Replace 'newline' by literal to restore <R2016b compatibility

### DIFF
--- a/matlab/@amimodel/compileAndLinkModel.m
+++ b/matlab/@amimodel/compileAndLinkModel.m
@@ -331,7 +331,7 @@ end
 
 function versionstring = getCompilerVersionString()
     [~,systemreturn] = system([mex.getCompilerConfigurations('c++').Details.CompilerExecutable ' --version']);
-    newlinePos = strfind(systemreturn,newline);
+    newlinePos = strfind(systemreturn, '\n');
     str = systemreturn(1:(newlinePos(1)-1));
     str = regexprep(str,'[\(\)]','');
     str = regexprep(str,'[\s\.\-]','_');


### PR DESCRIPTION
 (Fixes #493)