### PR TITLE
Reduce logsize

### DIFF
--- a/scripts/buildBNGL.sh
+++ b/scripts/buildBNGL.sh
@@ -13,10 +13,10 @@ cd ${AMICI_PATH}/ThirdParty
 if [ ! -d "BioNetGen-2.3.2" ]; then
     if [ ! -e "bionetgen.tar.gz" ]; then
         if [[ "$OSTYPE" == "linux-gnu" ]]; then
-            wget -O bionetgen.tar.gz https://bintray.com/jczech/bionetgen/download_file?file_path=BioNetGen-2.3.2-linux.tar.gz
+            wget -q -O bionetgen.tar.gz https://bintray.com/jczech/bionetgen/download_file?file_path=BioNetGen-2.3.2-linux.tar.gz
         elif [[ "$OSTYPE" == "darwin"* ]]; then
-            wget -O bionetgen.tar.gz https://bintray.com/jczech/bionetgen/download_file?file_path=BioNetGen-2.3.2-osx.tar.gz
+            wget -q -O bionetgen.tar.gz https://bintray.com/jczech/bionetgen/download_file?file_path=BioNetGen-2.3.2-osx.tar.gz
         fi
     fi
-    tar -xvzf bionetgen.tar.gz
+    tar -xzf bionetgen.tar.gz
 fi

--- a/scripts/buildCpputest.sh
+++ b/scripts/buildCpputest.sh
@@ -23,6 +23,6 @@ fi
 cd cpputest-master
 mkdir -p build
 cd build
-cmake -DTESTS=OFF -DBUILD_TESTING=OFF -DC++11=ON .. -quiet
+cmake -DTESTS=OFF -DBUILD_TESTING=OFF -DC++11=ON ..
 make -j4
 

--- a/scripts/buildCpputest.sh
+++ b/scripts/buildCpputest.sh
@@ -14,15 +14,15 @@ export CPPUTEST_BUILD_DIR=${AMICI_PATH}/ThirdParty/cpputest-master/
 
 if [ ! -d "cpputest-master" ]; then
     if [ ! -e "cpputest-master.zip" ]; then
-        wget -O cpputest-master.zip https://codeload.github.com/cpputest/cpputest/zip/master
+        wget -q -O cpputest-master.zip https://codeload.github.com/cpputest/cpputest/zip/master
     fi
-    unzip cpputest-master.zip
+    unzip -q cpputest-master.zip
     #cd cpputest-master/ && ./autogen.sh && ./configure && make
 fi
 
 cd cpputest-master
 mkdir -p build
 cd build
-cmake -DTESTS=OFF -DBUILD_TESTING=OFF -DC++11=ON ..
+cmake -DTESTS=OFF -DBUILD_TESTING=OFF -DC++11=ON .. -quiet
 make -j4
 


### PR DESCRIPTION
size of travis log was always >10k lines, which makes it a bit hard to navigate. Let's remove the biggest offenders.