### PR TITLE
fix(ci) Fix premature exit of scripts/runNotebook.sh

### DIFF
--- a/scripts/deployPyPi.sh
+++ b/scripts/deployPyPi.sh
@@ -8,6 +8,10 @@ SCRIPT_PATH=$(dirname $BASH_SOURCE)
 AMICI_PATH=$(cd $SCRIPT_PATH/.. && pwd)
 
 pip3 install twine
+# in case we are running with pyenv, we need to update pyenv shims after installing packages with binaries
+if [[ -z "${PYENV_VERSION}" ]]; then
+    pyenv rehash
+fi
 
 # authentication via env variables set in travis
 twine upload $(ls -t ${AMICI_PATH}/build/python/amici-*.tar.gz | head -1)

--- a/scripts/runNotebook.sh
+++ b/scripts/runNotebook.sh
@@ -12,9 +12,11 @@ runNotebook () {
     tempfile=$(mktemp)
     jupyter nbconvert --debug --stdout --execute --ExecutePreprocessor.timeout=300 --to markdown $@ &> $tempfile
     ret=$?
-    if [[ $ret != 0 ]]; then cat $tempfile; fi
+    if [[ $ret != 0 ]]; then
+      cat $tempfile
+      exit $ret
+    fi
     rm $tempfile
-    exit $ret
     set -e
 }
 


### PR DESCRIPTION
- fix(ci) Fix premature exit of scripts/runNotebook.sh 
- fix(deploy) Update pyenv shims to find twine (fixes #572)