### PR TITLE
Fix sign in undamped Newton step.

### DIFF
--- a/src/steadystateproblem.cpp
+++ b/src/steadystateproblem.cpp
@@ -180,7 +180,7 @@ void SteadystateProblem::applyNewtonsMethod(ReturnData *rdata, Model *model,
         }
 
         /* Try a full, undamped Newton step */
-        N_VLinearSum(1.0, x_old.getNVector(), gamma, delta.getNVector(), x->getNVector());
+        N_VLinearSum(1.0, x_old.getNVector(), -gamma, delta.getNVector(), x->getNVector());
 
         /* Compute new xdot and residuals */
         model->fxdot(*t, x, &dx, &xdot);


### PR DESCRIPTION
First, in NewtonSolver::getStep() a passed-in delta vector gets
a reverse sign by calling 'delta->minus();' and then its passed to
NewtonSolver::linsolveSPBCG via NewtonSolver::solveLinearSystem
where the sign is again reversed (xdot = *ns_delta; xdot.minus();)

Therefore -gamma must be applied in the Newton step otherwise the
Newton method does not converge at all.