### PR TITLE
Fix edata to df

### DIFF
--- a/python/amici/pandas.py
+++ b/python/amici/pandas.py
@@ -14,6 +14,7 @@ def getDataObservablesAsDataFrame(model, edata_list, by_id=False):
     Arguments:
         model: Model instance.
         edata_list: list of ExpData instances with experimental data.
+            May also be a single ExpData instance.
         by_id: bool (optional, default = False)
             If True, uses observable ids as identifiers in dataframe,
             otherwise the possibly more descriptive observable names
@@ -64,7 +65,9 @@ def getSimulationObservablesAsDataFrame(
     Arguments:
         model: Model instance.
         edata_list: list of ExpData instances with experimental data.
+            May also be a single ExpData instance.
         rdata_list: list of ReturnData instances corresponding to ExpData.
+            May also be a single ReturnData instance.
         by_id: bool, optional (default = False)
             If True, ids are used as identifiers, otherwise the possibly more
             descriptive names.
@@ -115,7 +118,9 @@ def getSimulationStatesAsDataFrame(
     Arguments:
         model: Model instance.
         edata_list: list of ExpData instances with experimental data.
+            May also be a single ExpData instance.
         rdata_list: list of ReturnData instances corresponding to ExpData.
+            May also be a single ReturnData instance.
         by_id: bool, optional (default = False)
             If True, ids are used as identifiers, otherwise the possibly more
             descriptive names.
@@ -164,7 +169,9 @@ def getResidualsAsDataFrame(model, edata_list, rdata_list, by_id=False):
     Arguments:
         model: Model instance.
         edata_list: list of ExpData instances with experimental data.
+            May also be a single ExpData instance.
         rdata_list: list of ReturnData instances corresponding to ExpData.
+            May also be a single ReturnData instance.
         by_id: bool, optional (default = False)
             If True, ids are used as identifiers, otherwise the possibly more
             descriptive names.

--- a/python/amici/pandas.py
+++ b/python/amici/pandas.py
@@ -280,7 +280,7 @@ def _get_extended_observable_cols(model, by_id) -> list:
     return \
         ['time', 'datatype', 't_presim'] + \
         _get_names_or_ids(model, 'FixedParameter', by_id=by_id) + \
-        [name + '_preeq' for name in 
+        [name + '_preeq' for name in
             _get_names_or_ids(model, 'FixedParameter', by_id=by_id)] + \
         [name + '_presim' for name in
             _get_names_or_ids(model, 'FixedParameter', by_id=by_id)] + \
@@ -449,7 +449,7 @@ def constructEdataFromDataFrame(df, model, condition, by_id=False):
     # fill in fixed parameters
     edata.fixedParameters = \
         condition[_get_names_or_ids(model, 'FixedParameter', by_id=by_id)].values
-    
+
     # fill in preequilibration parameters
     if any([overwrite_preeq[key] != condition[key] for key in
             overwrite_preeq.keys()]):

--- a/python/amici/pandas.py
+++ b/python/amici/pandas.py
@@ -48,7 +48,7 @@ def getDataObservablesAsDataFrame(model, edata_list, by_id=False):
                 datadict[obs] = npdata['observedData'][i_time, i_obs]
                 datadict[obs + '_std'] = \
                     npdata['observedDataStdDev'][i_time, i_obs]
-    
+
             # add conditions
             _fill_conditions_dict(datadict, model, edata, by_id=by_id)
 
@@ -82,7 +82,7 @@ def getSimulationObservablesAsDataFrame(
 
     # list of all column names using either names or ids
     cols = _get_extended_observable_cols(model, by_id=by_id)
-    
+
     # initialize dataframe with columns
     df_rdata = pd.DataFrame(columns=cols)
 
@@ -101,7 +101,7 @@ def getSimulationObservablesAsDataFrame(
 
             # use edata to fill conditions columns
             _fill_conditions_dict(datadict, model, edata, by_id=by_id)
-            
+
             # append to dataframe
             df_rdata.loc[len(df_rdata)] = datadict
 
@@ -332,9 +332,9 @@ def _get_state_cols(model, by_id):
     return \
         ['time', 't_presim'] + \
         _get_names_or_ids(model, 'FixedParameter', by_id=by_id) + \
-        [name + '_preeq' for name in \
+        [name + '_preeq' for name in
             _get_names_or_ids(model, 'FixedParameter', by_id=by_id)] + \
-        [name + '_presim' for name in \
+        [name + '_presim' for name in
             _get_names_or_ids(model, 'FixedParameter', by_id=by_id)] + \
         _get_names_or_ids(model, 'State', by_id=by_id)
 
@@ -455,7 +455,7 @@ def constructEdataFromDataFrame(df, model, condition, by_id=False):
             overwrite_preeq.keys()]):
         edata.fixedParametersPreequilibration = \
             _get_specialized_fixed_parameters(
-                model, condition,overwrite_preeq, by_id=by_id)
+                model, condition, overwrite_preeq, by_id=by_id)
     elif len(overwrite_preeq.keys()):
         edata.fixedParametersPreequilibration = copy.deepcopy(
             edata.fixedParameters
@@ -465,7 +465,7 @@ def constructEdataFromDataFrame(df, model, condition, by_id=False):
     if any([overwrite_presim[key] != condition[key] for key in
             overwrite_presim.keys()]):
         edata.fixedParametersPresimulation = _get_specialized_fixed_parameters(
-            model, condition,overwrite_presim, by_id=by_id
+            model, condition, overwrite_presim, by_id=by_id
         )
     elif len(overwrite_presim.keys()):
         edata.fixedParametersPresimulation = copy.deepcopy(

--- a/python/amici/pandas.py
+++ b/python/amici/pandas.py
@@ -26,7 +26,7 @@ def getDataObservablesAsDataFrame(model, edata_list, by_id=False):
     Raises:
 
     """
-    if isinstance(edata_list, amici.amici.ExpData):
+    if isinstance(edata_list, (amici.amici.ExpData, amici.amici.ExpDataPtr)):
         edata_list = [edata_list]
 
     # list of all column names using either ids or names
@@ -78,9 +78,9 @@ def getSimulationObservablesAsDataFrame(
     Raises:
 
     """
-    if isinstance(edata_list, amici.amici.ExpData):
+    if isinstance(edata_list, (amici.amici.ExpData, amici.amici.ExpDataPtr)):
         edata_list = [edata_list]
-    if isinstance(rdata_list, amici.amici.ReturnData):
+    if isinstance(rdata_list, (amici.amici.ReturnData, amici.amici.ReturnDataPtr)):
         rdata_list = [rdata_list]
 
     # list of all column names using either names or ids
@@ -131,9 +131,9 @@ def getSimulationStatesAsDataFrame(
     Raises:
 
     """
-    if isinstance(edata_list, amici.amici.ExpData):
+    if isinstance(edata_list, (amici.amici.ExpData, amici.amici.ExpDataPtr)):
         edata_list = [edata_list]
-    if isinstance(rdata_list, amici.amici.ReturnData):
+    if isinstance(rdata_list, (amici.amici.ReturnData, amici.amici.ReturnDataPtr)):
         rdata_list = [rdata_list]
 
     # get conditions and state column names by name or id
@@ -182,9 +182,9 @@ def getResidualsAsDataFrame(model, edata_list, rdata_list, by_id=False):
     Raises:
 
     """
-    if isinstance(edata_list, amici.amici.ExpData):
+    if isinstance(edata_list, (amici.amici.ExpData, amici.amici.ExpDataPtr)):
         edata_list = [edata_list]
-    if isinstance(rdata_list, amici.amici.ReturnData):
+    if isinstance(rdata_list, (amici.amici.ReturnData, amici.amici.ReturnDataPtr)):
         rdata_list = [rdata_list]
 
     # create observable and simulation dataframes

--- a/python/amici/pandas.py
+++ b/python/amici/pandas.py
@@ -375,10 +375,10 @@ def _get_names_or_ids(model, variable, by_id):
 
     # extract labels
     if not by_id and len(set(namegetter())) == len(namegetter()) \
-            and model.hasObservableNames():
+            and getattr(model, f"has{variable}Names")():
         # use variable names
         return list(namegetter())
-    elif model.hasObservableIds():
+    elif getattr(model, f"has{variable}Ids")():
         # use variable ids
         return list(idgetter())
     else:

--- a/python/amici/pandas.py
+++ b/python/amici/pandas.py
@@ -382,9 +382,13 @@ def _get_names_or_ids(model, variable, by_id):
         # use variable ids
         return list(idgetter())
     else:
-        # unable to create unique lables
-        raise RuntimeError('Model Observable Names are not unique and '
-                           'Observable Ids are not set. ')
+        # unable to create unique labels
+        if by_id:
+            raise RuntimeError(f"Model {variable} ids are not set.")
+        else:
+            raise RuntimeError(
+                f"Model {variable} names are not unique and "
+                f"{variable} ids are not set.")
 
 
 def _get_specialized_fixed_parameters(

--- a/python/amici/pandas.py
+++ b/python/amici/pandas.py
@@ -2,30 +2,37 @@ import pandas as pd
 import numpy as np
 import math
 import copy
+
 from .numpy import edataToNumPyArrays
+import amici
 from amici import ExpData
 
+
 def getDataObservablesAsDataFrame(model, edata_list, by_id=False):
-    """ Write Observables from experimental data as DataFrame
+    """ 
+    Write Observables from experimental data as DataFrame.
 
     Arguments:
-        model: Model instance
-        edata_list: list of ExpData instances with experimental data
+        model: Model instance.
+        edata_list: list of ExpData instances with experimental data.
         by_id: bool (optional, default = False)
             If True, uses observable ids as identifiers in dataframe,
             otherwise the possibly more descriptive observable names
             are used.
 
     Returns:
-        pandas DataFrame with conditions and observables
+        pandas DataFrame with conditions and observables.
 
     Raises:
 
     """
+    if isinstance(edata_list, amici.amici.ExpData):
+        edata_list = [edata_list]
 
+    # find observable column names using either parameter ids or names
     cols = _get_extended_observable_cols(model, by_id=by_id)
-    df_edata = pd.DataFrame(columns=cols)
 
+    df_edata = pd.DataFrame(columns=cols)
     for edata in edata_list:
         npdata = edataToNumPyArrays(edata)
         for i_time, timepoint in enumerate(edata.getTimepoints()):
@@ -64,6 +71,8 @@ def getSimulationObservablesAsDataFrame(
     Raises:
 
     """
+    if isinstance(edata_list, amici.amici.ExpData):
+        edata_list = [edata_list]
 
     cols = _get_extended_observable_cols(model, by_id=by_id)
     df_rdata = pd.DataFrame(columns=cols)
@@ -104,6 +113,10 @@ def getSimulationStatesAsDataFrame(
     Raises:
 
     """
+    if isinstance(edata_list, amici.amici.ExpData):
+        edata_list = [edata_list]
+    if isinstance(rdata_list, amici.amici.ReturnData):
+        rdata_list = [rdata_list]
 
     cols = _get_state_cols(model, by_id=by_id)
     df_rdata = pd.DataFrame(columns=cols)
@@ -141,6 +154,10 @@ def getResidualsAsDataFrame(model, edata_list, rdata_list, by_id=False):
     Raises:
 
     """
+    if isinstance(edata_list, amici.amici.ExpData):
+        edata_list = [edata_list]
+    if isinstance(rdata_list, amici.amici.ReturnData):
+        rdata_list = [rdata_list]
 
     df_edata = getDataObservablesAsDataFrame(model, edata_list, by_id=by_id)
     df_rdata = getSimulationObservablesAsDataFrame(model, edata_list,

--- a/python/amici/pandas.py
+++ b/python/amici/pandas.py
@@ -26,7 +26,7 @@ def getDataObservablesAsDataFrame(model, edata_list, by_id=False):
     Raises:
 
     """
-    if isinstance(edata_list, amici.amici.ExpData):
+    if isinstance(edata_list, amici.ExpData):
         edata_list = [edata_list]
 
     # list of all column names using either ids or names
@@ -78,9 +78,9 @@ def getSimulationObservablesAsDataFrame(
     Raises:
 
     """
-    if isinstance(edata_list, amici.amici.ExpData):
+    if isinstance(edata_list, amici.ExpData):
         edata_list = [edata_list]
-    if isinstance(rdata_list, amici.amici.ReturnData):
+    if isinstance(rdata_list, amici.ReturnData):
         rdata_list = [rdata_list]
 
     # list of all column names using either names or ids
@@ -131,9 +131,9 @@ def getSimulationStatesAsDataFrame(
     Raises:
 
     """
-    if isinstance(edata_list, amici.amici.ExpData):
+    if isinstance(edata_list, amici.ExpData):
         edata_list = [edata_list]
-    if isinstance(rdata_list, amici.amici.ReturnData):
+    if isinstance(rdata_list, amici.ReturnData):
         rdata_list = [rdata_list]
 
     # get conditions and state column names by name or id
@@ -182,9 +182,9 @@ def getResidualsAsDataFrame(model, edata_list, rdata_list, by_id=False):
     Raises:
 
     """
-    if isinstance(edata_list, amici.amici.ExpData):
+    if isinstance(edata_list, amici.ExpData):
         edata_list = [edata_list]
-    if isinstance(rdata_list, amici.amici.ReturnData):
+    if isinstance(rdata_list, amici.ReturnData):
         rdata_list = [rdata_list]
 
     # create observable and simulation dataframes

--- a/python/amici/pandas.py
+++ b/python/amici/pandas.py
@@ -361,7 +361,7 @@ def _get_names_or_ids(model, variable, by_id):
     variable_options = ['Parameter', 'FixedParameter', 'Observable', 'State']
     if variable not in variable_options:
         raise ValueError('variable must be in ' + str(variable_options))
-    
+
     # functions to extract attributes
     namegetter = getattr(model, 'get' + variable + 'Names')
     idgetter = getattr(model, 'get' + variable + 'Ids')

--- a/python/amici/pandas.py
+++ b/python/amici/pandas.py
@@ -26,7 +26,7 @@ def getDataObservablesAsDataFrame(model, edata_list, by_id=False):
     Raises:
 
     """
-    if isinstance(edata_list, amici.ExpData):
+    if isinstance(edata_list, amici.amici.ExpData):
         edata_list = [edata_list]
 
     # list of all column names using either ids or names
@@ -78,9 +78,9 @@ def getSimulationObservablesAsDataFrame(
     Raises:
 
     """
-    if isinstance(edata_list, amici.ExpData):
+    if isinstance(edata_list, amici.amici.ExpData):
         edata_list = [edata_list]
-    if isinstance(rdata_list, amici.ReturnData):
+    if isinstance(rdata_list, amici.amici.ReturnData):
         rdata_list = [rdata_list]
 
     # list of all column names using either names or ids
@@ -131,9 +131,9 @@ def getSimulationStatesAsDataFrame(
     Raises:
 
     """
-    if isinstance(edata_list, amici.ExpData):
+    if isinstance(edata_list, amici.amici.ExpData):
         edata_list = [edata_list]
-    if isinstance(rdata_list, amici.ReturnData):
+    if isinstance(rdata_list, amici.amici.ReturnData):
         rdata_list = [rdata_list]
 
     # get conditions and state column names by name or id
@@ -182,9 +182,9 @@ def getResidualsAsDataFrame(model, edata_list, rdata_list, by_id=False):
     Raises:
 
     """
-    if isinstance(edata_list, amici.ExpData):
+    if isinstance(edata_list, amici.amici.ExpData):
         edata_list = [edata_list]
-    if isinstance(rdata_list, amici.ReturnData):
+    if isinstance(rdata_list, amici.amici.ReturnData):
         rdata_list = [rdata_list]
 
     # create observable and simulation dataframes


### PR DESCRIPTION
Give ``amici.pandas.py`` functions an option ``by_id=False``. This is always carried on to the ``_get_names_or_ids`` function which now won't try to use names if True. The default behavior is not changed.

Handling of empty values not implemented yet, since there is a check that fails when there are multiple empty names anyway.

fixes #607 .