### PR TITLE
Fix initial amounts (fix #674)

### DIFF
--- a/matlab/@amimodel/generateMatlabWrapper.m
+++ b/matlab/@amimodel/generateMatlabWrapper.m
@@ -309,9 +309,6 @@ function generateMatlabWrapper(nx, ny, np, nk, nz, o2flag, amimodelo2, wrapperFi
     fprintf(fid,['if(~all(tout==sort(tout)))\n']);
     fprintf(fid,['    error(''Provided time vector is not monotonically increasing!'');\n']);
     fprintf(fid,['end\n']);
-    fprintf(fid,['if(not(length(tout)==length(unique(tout))))\n']);
-    fprintf(fid,['    error(''Provided time vector has non-unique entries!!'');\n']);
-    fprintf(fid,['end\n']);
     fprintf(fid,['if(max(options_ami.sens_ind)>' num2str(np) ')\n']);
     fprintf(fid,['    error(''Sensitivity index exceeds parameter dimension!'')\n']);
     fprintf(fid,['end\n']);

--- a/python/amici/sbml_import.py
+++ b/python/amici/sbml_import.py
@@ -362,14 +362,15 @@ class SbmlImporter:
         concentrations = [spec.getInitialConcentration() for spec in species]
         amounts = [spec.getInitialAmount() for spec in species]
 
-        if all(self.speciesHasOnlySubstanceUnits):
-            warnings.warn('SBML file declares no concentrations, but only '
-                          'substance units. Using amounts instea of '
-                          'concentrations.')
-            concentrations = amounts.copy()
+#        if all(self.speciesHasOnlySubstanceUnits):
+#            warnings.warn('SBML file declares no concentrations, but only '
+ #                         'substance units. Using amounts instea of '
+ ##                         'concentrations.')
+ #           concentrations = amounts.copy()
 
         def getSpeciesInitial(index, conc):
-            if not math.isnan(conc):
+            if not self.speciesHasOnlySubstanceUnits[index] \
+                    or not math.isnan(conc):
                 return sp.sympify(conc)
             if not math.isnan(amounts[index]):
                 return \

--- a/python/amici/sbml_import.py
+++ b/python/amici/sbml_import.py
@@ -364,9 +364,10 @@ class SbmlImporter:
 
         def getSpeciesInitial(index, conc):
             if not (self.speciesHasOnlySubstanceUnits[index] or math.isnan(
-                    conc)):
+                    conc) or species[index].isSetInitialConcentration()):
                 return sp.sympify(conc)
-            if not math.isnan(amounts[index]):
+            if species[index].isSetInitialAmount() and not math.isnan(
+                    amounts[index]):
                 return \
                     sp.sympify(amounts[index]) / self.speciesCompartment[index]
             return self.symbols['species']['identifier'][index]

--- a/python/amici/sbml_import.py
+++ b/python/amici/sbml_import.py
@@ -362,15 +362,9 @@ class SbmlImporter:
         concentrations = [spec.getInitialConcentration() for spec in species]
         amounts = [spec.getInitialAmount() for spec in species]
 
-#        if all(self.speciesHasOnlySubstanceUnits):
-#            warnings.warn('SBML file declares no concentrations, but only '
- #                         'substance units. Using amounts instea of '
- ##                         'concentrations.')
- #           concentrations = amounts.copy()
-
         def getSpeciesInitial(index, conc):
-            if not self.speciesHasOnlySubstanceUnits[index] \
-                    or not math.isnan(conc):
+            if not (self.speciesHasOnlySubstanceUnits[index] or math.isnan(
+                    conc)):
                 return sp.sympify(conc)
             if not math.isnan(amounts[index]):
                 return \

--- a/python/amici/sbml_import.py
+++ b/python/amici/sbml_import.py
@@ -362,6 +362,12 @@ class SbmlImporter:
         concentrations = [spec.getInitialConcentration() for spec in species]
         amounts = [spec.getInitialAmount() for spec in species]
 
+        if all(self.speciesHasOnlySubstanceUnits):
+            warnings.warn('SBML file declares no concentrations, but only '
+                          'substance units. Using amounts instea of '
+                          'concentrations.')
+            concentrations = amounts.copy()
+
         def getSpeciesInitial(index, conc):
             if not math.isnan(conc):
                 return sp.sympify(conc)


### PR DESCRIPTION
I use a quick check whether or not only substance units are used for a given species. If this is the case, no initialConcentration will be defined, but an initialAmount. This means that the corresponding field has to be used.
This was already implemented but the if-clause which checks for that simply did not cover this case...