### PR TITLE
Make wurlitzer non-optional requirement for AMICI python package

### DIFF
--- a/python/sdist/setup.py
+++ b/python/sdist/setup.py
@@ -182,11 +182,13 @@ def main():
                           'python-libsbml',
                           'h5py',
                           'pandas',
-                          'pkgconfig'],
+                          'pkgconfig',
+                          'wurlitzer'],
         setup_requires=['setuptools>=40.6.3'],
         python_requires='>=3.6',
-        extras_require={'wurlitzer': ['wurlitzer'],
-                        'petab': ['petab>=0.0.0a14']},
+        extras_require={
+            'petab': ['petab>=0.0.0a14']
+        },
         package_data={
             'amici': ['amici/include/amici/*',
                       'src/*template*',


### PR DESCRIPTION
Wurlitzer is required to properly show AMICI C++ output in Jupyter notebooks. As this is a non-exotic use case and the package is very lightweight, we should require it by default. Not displaying AMICI errors seems like a bigger problem than having one potentially extraneous package installed.