### PR TITLE
Fix(cmake): -E option is not available in all sed versions. 

### DIFF
--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -1,6 +1,6 @@
 find_package(Git)
 if(Git_FOUND)
-    execute_process(COMMAND sh -c "${GIT_EXECUTABLE} describe --abbrev=4 --dirty=-dirty --always --tags  | cut -c 2- | tr -d '\n' | sed -E s/-/./"
+    execute_process(COMMAND sh -c "${GIT_EXECUTABLE} describe --abbrev=4 --dirty=-dirty --always --tags  | cut -c 2- | tr -d '\n' | sed --regexp-extended s/-/./"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         OUTPUT_VARIABLE PROJECT_VERSION_GIT
         )

--- a/scripts/run-valgrind.sh
+++ b/scripts/run-valgrind.sh
@@ -13,7 +13,7 @@ cd ${AMICI_PATH}/build/tests/cpputest/
 
 VALGRIND_OPTS="--leak-check=full --error-exitcode=1 --trace-children=yes --show-leak-kinds=definite"
 set -x
-for MODEL in $(ctest -N | grep "Test[ ]*#" | grep -v unittests | sed -E 's/ *Test[ ]*#[0-9]+: model_(.*)_test/\1/')
+for MODEL in $(ctest -N | grep "Test[ ]*#" | grep -v unittests | sed --regexp-extended 's/ *Test[ ]*#[0-9]+: model_(.*)_test/\1/')
     do cd ${AMICI_PATH}/build/tests/cpputest/${MODEL}/ && valgrind ${VALGRIND_OPTS} ./model_${MODEL}_test
 done
 cd ${AMICI_PATH}/build/tests/cpputest/unittests/ && valgrind ${VALGRIND_OPTS} ./unittests


### PR DESCRIPTION
Neither is the equivalent -r. Use --regexp-extended instead