### PR TITLE
Simplify symbolic sensitivity expressions during Python SBML import

### DIFF
--- a/documentation/development.md
+++ b/documentation/development.md
@@ -98,8 +98,10 @@ described below:
   case for all existing code, any new contributions should do so. 
 
 * We use Python [type hints](https://docs.python.org/3/library/typing.html)
-  for all functions. In Python code type hints should be used instead of
-  doxygen `@type`. (All legacy `@type` attributes are to be removed.)
+  for all functions (but not for class attributes, since they are not supported
+  by the current Python doxygen filter). In Python code type hints should be
+  used instead of doxygen `@type`. (All legacy `@type` attributes are to be
+  removed.)
     
   For function docstrings, follow this format:
   

--- a/python/amici/ode_export.py
+++ b/python/amici/ode_export.py
@@ -809,7 +809,7 @@ class ODEModel:
         }
 
         self._lock_total_derivative = False
-        self._simplify: bool = simplify
+        self._simplify = simplify
 
     def import_from_sbml_importer(self, si):
         """Imports a model specification from a amici.SBMLImporter instance.

--- a/python/amici/ode_export.py
+++ b/python/amici/ode_export.py
@@ -825,7 +825,8 @@ class ODEModel:
         self._eqs['dxdotdw'] = si.stoichiometricMatrix
         self._eqs['w'] = si.fluxVector
         self._syms['w'] = sp.Matrix(
-            [sp.Symbol(f'flux_r{idx}') for idx in range(len(si.fluxVector))]
+            [sp.Symbol(f'flux_r{idx}', real=True)
+             for idx in range(len(si.fluxVector))]
         )
         self._eqs['dxdotdx'] = sp.zeros(si.stoichiometricMatrix.shape[0])
         if len(si.stoichiometricMatrix):
@@ -1160,12 +1161,12 @@ class ODEModel:
                 for comp in getattr(self, component)
             ])
             self._strippedsyms[name] = sp.Matrix([
-                sp.Symbol(comp.get_name())
+                sp.Symbol(comp.get_name(), real=True)
                 for comp in getattr(self, component)
             ])
             if name == 'y':
                 self._syms['my'] = sp.Matrix([
-                    sp.Symbol(f'm{strip_pysb(comp.get_id())}')
+                    sp.Symbol(f'm{strip_pysb(comp.get_id())}', real=True)
                     for comp in getattr(self, component)
                 ])
             return
@@ -1178,7 +1179,7 @@ class ODEModel:
             return
         elif name == 'dtcldp':
             self._syms[name] = sp.Matrix([
-                sp.Symbol(f's{strip_pysb(tcl.get_id())}')
+                sp.Symbol(f's{strip_pysb(tcl.get_id())}', real=True)
                 for tcl in self._conservationlaws
             ])
             return
@@ -1193,7 +1194,7 @@ class ODEModel:
             length = len(self.eq(name))
 
         self._syms[name] = sp.Matrix([
-            sp.Symbol(f'{name}{i}') for i in range(length)
+            sp.Symbol(f'{name}{i}', real=True) for i in range(length)
         ])
 
     def generateBasicVariables(self):
@@ -1509,7 +1510,7 @@ class ODEModel:
 
         if min(eq.shape) and min(sym_var.shape) \
                 and eq.is_zero is not True and sym_var.is_zero is not True:
-            self._eqs[name] = eq.jacobian(sym_var)
+            self._eqs[name] = sp.simplify(eq.jacobian(sym_var))
         else:
             self._eqs[name] = sp.zeros(eq.shape[0], self.sym(var).shape[0])
 
@@ -1556,7 +1557,7 @@ class ODEModel:
             if dydx_name is None:
                 dydx_name = f'd{eq}d{chainvar}'
             if dxdz_name is None:
-                dxdz_name =  f'd{chainvar}d{var}'
+                dxdz_name = f'd{chainvar}d{var}'
 
             dydx = self.sym_or_eq(name, dydx_name)
             dxdz = self.sym_or_eq(name, dxdz_name)
@@ -1799,7 +1800,7 @@ class ODEExporter:
         modelSwigPath: path to the generated swig files @type str
 
         allow_reinit_fixpar_initcond: indicates whether reinitialization of
-        initial states depending on fixedParmeters is allowed for this model
+        initial states depending on fixedParameters is allowed for this model
         @type bool
     """
 
@@ -2628,7 +2629,7 @@ def strip_pysb(symbol):
     # this ensures that the pysb type specific __repr__ is used when converting
     # to string
     if pysb and isinstance(symbol, pysb.Component):
-        return sp.Symbol(symbol.name)
+        return sp.Symbol(symbol.name, real=True)
     else:
         # in this case we will use sympy specific transform anyways
         return symbol
@@ -2834,7 +2835,7 @@ def csc_matrix(matrix, name, base_index=0):
         for row in range(0, matrix.rows):
             if not (matrix[row, col] == 0):
                 symbolName = f'{name}{symbol_name_idx}'
-                sparseMatrix[row, col] = sp.Symbol(symbolName)
+                sparseMatrix[row, col] = sp.Symbol(symbolName, real=True)
                 symbolList.append(symbolName)
                 sparseList.append(matrix[row, col])
                 symbolRowVals.append(row)

--- a/python/amici/sbml_import.py
+++ b/python/amici/sbml_import.py
@@ -244,7 +244,7 @@ class SbmlImporter:
         self.reset_symbols()
         self.processSBML(constantParameters)
         self.processObservables(observables, sigmas, noise_distributions)
-        ode_model = ODEModel()
+        ode_model = ODEModel(simplify=True)
         ode_model.import_from_sbml_importer(self)
         exporter = ODEExporter(
             ode_model,

--- a/python/amici/sbml_import.py
+++ b/python/amici/sbml_import.py
@@ -342,10 +342,10 @@ class SbmlImporter:
 
         """
         for s in self.sbml.getListOfSpecies():
-            self.local_symbols[s.getId()] = sp.Symbol(s.getId())
+            self.local_symbols[s.getId()] = sp.Symbol(s.getId(), real=True)
 
         for p in self.sbml.getListOfParameters():
-            self.local_symbols[p.getId()] = sp.Symbol(p.getId())
+            self.local_symbols[p.getId()] = sp.Symbol(p.getId(), real=True)
 
     def processSpecies(self):
         """Get species information from SBML model.
@@ -365,12 +365,12 @@ class SbmlImporter:
         }
 
         self.symbols['species']['identifier'] = sp.Matrix(
-            [sp.Symbol(spec.getId()) for spec in species]
+            [sp.Symbol(spec.getId(), real=True) for spec in species]
         )
         self.symbols['species']['name'] = [spec.getName() for spec in species]
 
         self.speciesCompartment = sp.Matrix(
-            [sp.Symbol(spec.getCompartment()) for spec in species]
+            [sp.Symbol(spec.getCompartment(), real=True) for spec in species]
         )
 
         self.constantSpecies = [species_element.getId()
@@ -448,7 +448,8 @@ class SbmlImporter:
         self.symbols['species']['value'] = species_initial
 
         if self.sbml.isSetConversionFactor():
-            conversion_factor = sp.Symbol(self.sbml.getConversionFactor())
+            conversion_factor = sp.Symbol(self.sbml.getConversionFactor(),
+                                          real=True)
         else:
             conversion_factor = 1.0
 
@@ -516,7 +517,7 @@ class SbmlImporter:
             settings = loop_settings[partype]
 
             self.symbols[partype]['identifier'] = sp.Matrix(
-                [sp.Symbol(par.getId()) for par in settings['var']]
+                [sp.Symbol(par.getId(), real=True) for par in settings['var']]
             )
             self.symbols[partype]['name'] = [
                 par.getName() for par in settings['var']
@@ -547,7 +548,7 @@ class SbmlImporter:
         """
         compartments = self.sbml.getListOfCompartments()
         self.compartmentSymbols = sp.Matrix(
-            [sp.Symbol(comp.getId()) for comp in compartments]
+            [sp.Symbol(comp.getId(), real=True) for comp in compartments]
         )
         self.compartmentVolume = sp.Matrix(
             [sp.sympify(comp.getVolume()) if comp.isSetVolume()
@@ -620,7 +621,7 @@ class SbmlImporter:
                     if symMath is None:
                         symMath = sp.sympify(element.getStoichiometry())
                 elif element.getId() in rulevars:
-                    return sp.Symbol(element.getId())
+                    return sp.Symbol(element.getId(), real=True)
                 else:
                     # dont put the symbol if it wont get replaced by a
                     # rule
@@ -712,7 +713,8 @@ class SbmlImporter:
         volumevars = self.compartmentVolume.free_symbols
         compartmentvars = self.compartmentSymbols.free_symbols
         parametervars = sp.Matrix([
-            sp.Symbol(par.getId()) for par in self.sbml.getListOfParameters()
+            sp.Symbol(par.getId(), real=True)
+            for par in self.sbml.getListOfParameters()
         ])
         stoichvars = self.stoichiometricMatrix.free_symbols
 
@@ -810,8 +812,8 @@ class SbmlImporter:
         Raises:
 
         """
-        sbmlTimeSymbol = sp.Symbol('time')
-        amiciTimeSymbol = sp.Symbol('t')
+        sbmlTimeSymbol = sp.Symbol('time', real=True)
+        amiciTimeSymbol = sp.Symbol('t', real=True)
 
         self.replaceInAllExpressions(sbmlTimeSymbol, amiciTimeSymbol)
 
@@ -903,11 +905,13 @@ class SbmlImporter:
                 f'x{index}' for index in range(len(speciesSyms))
             ]
             observableSyms = sp.Matrix(
-                [sp.symbols(f'y{index}', real=True) for index in range(len(speciesSyms))]
+                [sp.symbols(f'y{index}', real=True)
+                 for index in range(len(speciesSyms))]
             )
 
         sigmaYSyms = sp.Matrix(
-            [sp.symbols(f'sigma{symbol}', real=True) for symbol in observableSyms]
+            [sp.symbols(f'sigma{symbol}', real=True)
+             for symbol in observableSyms]
         )
         sigmaYValues = sp.Matrix(
             [1.0] * len(observableSyms)
@@ -942,7 +946,7 @@ class SbmlImporter:
         llhYValues = sp.Matrix(llhYValues)
 
         llhYSyms = sp.Matrix(
-            [sp.Symbol(f'J{symbol}') for symbol in observableSyms]
+            [sp.Symbol(f'J{symbol}', real=True) for symbol in observableSyms]
         )
 
         # set symbols
@@ -1002,8 +1006,8 @@ class SbmlImporter:
         """
         reservedSymbols = ['k','p','y','w']
         for str in reservedSymbols:
-            old_symbol = sp.Symbol(str)
-            new_symbol = sp.Symbol('amici_' + str)
+            old_symbol = sp.Symbol(str, real=True)
+            new_symbol = sp.Symbol('amici_' + str, real=True)
             self.replaceInAllExpressions(old_symbol, new_symbol)
             for symbol in self.symbols.keys():
                 if 'identifier' in self.symbols[symbol].keys():
@@ -1022,7 +1026,7 @@ class SbmlImporter:
 
         """
         constants = [
-            (sp.Symbol('avogadro'), sp.Symbol('6.02214179e23')),
+            (sp.Symbol('avogadro', real=True), sp.Symbol('6.02214179e23')),
         ]
         for constant, value in constants:
             # do not replace if any symbol is shadowing default definition


### PR DESCRIPTION
Fixes Infs in the Jacobian when using Hill-functions with states of 0.0.

Mark all sympy symbols as reals, which sometimes allows for additional simplifications.