### PR TITLE
PEtab import: adapt to new petab parameter mapping format change

### DIFF
--- a/.github/workflows/test-benchmark-collection-models.yml
+++ b/.github/workflows/test-benchmark-collection-models.yml
@@ -53,5 +53,5 @@ jobs:
     - name: Download and test benchmark collection
       run: |
         git clone --depth 1 https://github.com/benchmarking-initiative/Benchmark-Models-PEtab.git \
-          && export BENCHMARK_COLLECTION="$(pwd)/Benchmark-Models-PEtab/" \
+          && export BENCHMARK_COLLECTION="$(pwd)/Benchmark-Models-PEtab/Benchmark-Models/" \
           && tests/benchmark-models/test_benchmark_collection.sh

--- a/.github/workflows/test-benchmark-collection-models.yml
+++ b/.github/workflows/test-benchmark-collection-models.yml
@@ -4,11 +4,11 @@ on:
     branches:
       - develop
       - master
-      - fix_ci
 
   pull_request:
     branches:
       - master
+      - develop
 
 jobs:
   build:
@@ -30,7 +30,7 @@ jobs:
       run: |
         pip3 install --upgrade --user wheel \
           && pip3 install --upgrade --user setuptools
-    - run: pip3 install pytest shyaml petab>=0.1.2
+    - run: pip3 install pytest shyaml petab>=0.1.3
     - run: |
         echo ::add-path::${HOME}/.local/bin/
         echo ::add-path::${GITHUB_WORKSPACE}/tests/performance/

--- a/.github/workflows/test-benchmark-collection-models.yml
+++ b/.github/workflows/test-benchmark-collection-models.yml
@@ -51,9 +51,8 @@ jobs:
 
     # retrieve test models
     - name: Download and test benchmark collection
-      # TODO do something more efficient than cloning this big repo
       run: |
-        git clone --depth 1 https://github.com/LeonardSchmiester/Benchmark-Models.git \
-          && cd Benchmark-Models && git checkout hackathon && cd .. \
-          && export BENCHMARK_COLLECTION="$(pwd)/Benchmark-Models/hackathon_contributions_new_data_format/" \
+        git clone --depth 1 https://github.com/benchmarking-initiative/Benchmark-Models-PEtab.git \
+          && cd Benchmark-Models-PEtab && git checkout hackathon && cd .. \
+          && export BENCHMARK_COLLECTION="$(pwd)/Benchmark-Models-PEtab/" \
           && tests/benchmark-models/test_benchmark_collection.sh

--- a/.github/workflows/test-benchmark-collection-models.yml
+++ b/.github/workflows/test-benchmark-collection-models.yml
@@ -53,6 +53,5 @@ jobs:
     - name: Download and test benchmark collection
       run: |
         git clone --depth 1 https://github.com/benchmarking-initiative/Benchmark-Models-PEtab.git \
-          && cd Benchmark-Models-PEtab && git checkout hackathon && cd .. \
           && export BENCHMARK_COLLECTION="$(pwd)/Benchmark-Models-PEtab/" \
           && tests/benchmark-models/test_benchmark_collection.sh

--- a/python/amici/petab_objective.py
+++ b/python/amici/petab_objective.py
@@ -34,7 +34,7 @@ def simulate_petab(
         solver: Optional[amici.Solver] = None,
         problem_parameters: Optional[Dict[str, float]] = None,
         simulation_conditions: Union[pd.DataFrame, Dict] = None,
-        parameter_mapping: List[petab.ParMappingDictTuple] = None,
+        parameter_mapping: List[petab.ParMappingDictQuadruple] = None,
         scaled_parameters: Optional[bool] = False,
         log_level: int = logging.WARNING
 ) -> Dict[str, Any]:

--- a/python/amici/petab_objective.py
+++ b/python/amici/petab_objective.py
@@ -192,7 +192,7 @@ def edatas_from_petab(
         simulation_conditions = \
             petab_problem.get_simulation_conditions_from_measurement_df()
 
-    # Get parameter mapping (need to overwrite scale mapping too)
+    # Get parameter mapping
     if parameter_mapping is None:
         parameter_mapping = \
             petab_problem.get_optimization_to_simulation_parameter_mapping(

--- a/python/sdist/setup.py
+++ b/python/sdist/setup.py
@@ -198,7 +198,7 @@ def main():
         setup_requires=['setuptools>=40.6.3'],
         python_requires='>=3.6',
         extras_require={
-            'petab': ['petab>=0.1.2']
+            'petab': ['petab>=0.1.3']
         },
         package_data={
             'amici': ['amici/include/amici/*',

--- a/tests/benchmark-models/benchmark_models.yaml
+++ b/tests/benchmark-models/benchmark_models.yaml
@@ -38,7 +38,7 @@ Fiedler_BMC2016:
   note: unchecked
 
 Fujita_SciSignal2010:
-  llh: -3975.060953726485
+  llh: 53.08749124997969
   note: benchmark collection reference value does not include condition data7..data12
 
 # Hass_PONE2017    None

--- a/tests/benchmark-models/benchmark_models.yaml
+++ b/tests/benchmark-models/benchmark_models.yaml
@@ -31,7 +31,7 @@ Crauste_CellSystems2017:
 
 Elowitz_Nature2000:
   llh: 111.57663643721794
-  note: benchmark collection reference value does not match, but model outputs do. maybe due to D2D data normalization
+  note: benchmark collection reference value matches up to sign when applying log10-correction +sum(log10(sim)) / 2
 
 Fiedler_BMC2016:
   llh: -117.16780323362
@@ -39,7 +39,6 @@ Fiedler_BMC2016:
 
 Fujita_SciSignal2010:
   llh: 53.08749124997969
-  note: benchmark collection reference value does not include condition data7..data12
 
 # Hass_PONE2017    None
 

--- a/tests/benchmark-models/benchmark_models.yaml
+++ b/tests/benchmark-models/benchmark_models.yaml
@@ -30,7 +30,7 @@ Crauste_CellSystems2017:
   note: benchmark collection only reports chi2 value, but llh value can be derived
 
 Elowitz_Nature2000:
-  llh: -4249.322017350108
+  llh: 111.57663643721794
   note: benchmark collection reference value does not match, but model outputs do. maybe due to D2D data normalization
 
 Fiedler_BMC2016:


### PR DESCRIPTION
* adapt to new paramet mapping format
* change benchmarking repository to github.com/benchmarking-initiative/benchmark-models-petab

Basically, now the "parameter mapping" is assumed to be a 4-tuple encompassing also the preeq mappings, and the scale mappings.

fixes #980 