### PR TITLE
Fix(core) Fix (re)initialization of sensitivities if ExpData::fixedParametersPreequilibration is set

### DIFF
--- a/src/forwardproblem.cpp
+++ b/src/forwardproblem.cpp
@@ -157,6 +157,7 @@ void ForwardProblem::handlePreequilibration() {
         model->initialize(x, dx, sx, sdx,
                           solver->getSensitivityOrder() >=
                               SensitivityOrder::first);
+        updateAndReinitStatesAndSensitivities(false);
     }
 
     // pre-equilibrate


### PR DESCRIPTION
Previously the solver was initialized when `Model` had the orginal `fixedParameters` set instead of those from `ExpData::fixedParametersPreequilibration` leading to potentially wrong initial sensitivities being used and resulting in incorrect `sllh`.