### PR TITLE
Enable use of SWIG 4.0 for CMake build

### DIFF
--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -2,7 +2,16 @@
 # Build additional AMICI interfaces via swig
 #
 
-find_package(SWIG REQUIRED 3)
+# Use most recent SWIG version available
+SET(CMAKE_FIND_PACKAGE_SORT_DIRECTION DEC)
+find_package(SWIG REQUIRED)
+
+set(SWIG_VERSION_MIN "3.0")
+if (${SWIG_VERSION} VERSION_LESS ${SWIG_VERSION_MIN})
+    message(FATAL_ERROR "Requiring SWIG>=${SWIG_VERSION_MIN} "
+                        "but found only ${SWIG_VERSION}.")
+endif()
+
 include(${SWIG_USE_FILE})
 
 set(AMICI_INTERFACE_LIST


### PR DESCRIPTION
So far restricted to swig3