### PR TITLE
Fix(python) Improved SWIG-finding for model compilation (Closes #978)

### DIFF
--- a/python/amici/setup.template.py
+++ b/python/amici/setup.template.py
@@ -29,6 +29,14 @@ class ModelBuildExt(build_ext):
 
         build_ext.build_extension(self, ext)
 
+    def find_swig(self) -> str:
+        """Find SWIG executable
+
+        Overrides horribly outdated distutils function."""
+
+        from amici.swig import find_swig
+        return find_swig()
+
 
 def get_model_sources() -> List[str]:
     """Get list of source files for the amici base library"""


### PR DESCRIPTION
For wrapping model code (as opposed to amici base extension), we so far relied on distutils to correctly detect a proper swig version, which was a bad idea (#978).