### PR TITLE
Force recompilation of all sources during python package installation

### DIFF
--- a/python/amici/custom_commands.py
+++ b/python/amici/custom_commands.py
@@ -113,6 +113,15 @@ class AmiciBuildCLib(build_clib):
         set_compiler_specific_library_options(
             libraries, self.compiler.compiler_type)
 
+        # Monkey-patch setuptools, to force recompilation of library sources
+        # --force does not work as expected
+
+        # need full import here, not module-level imported build_clib
+        import setuptools.command.build_clib
+        # the patched function may return anything but `([], [])` to trigger
+        # recompilation
+        setuptools.command.build_clib.newer_pairwise_group = lambda *_: None
+
         build_clib.build_libraries(self, libraries)
 
 

--- a/scripts/installAmiciSource.sh
+++ b/scripts/installAmiciSource.sh
@@ -21,7 +21,7 @@ if [[ $? ]]; then
     python3 -m venv ${AMICI_PATH}/build/venv --clear --without-pip
     source ${AMICI_PATH}/build/venv/bin/activate
     curl https://bootstrap.pypa.io/get-pip.py -o ${AMICI_PATH}/build/get-pip.py
-    python ${AMICI_PATH}/build/get-pip.py
+    python3 ${AMICI_PATH}/build/get-pip.py
 else
     set -e
     source ${AMICI_PATH}/build/venv/bin/activate


### PR DESCRIPTION
Fixes #1045

setuptools/distutils does not seem to do it's job, so monkey-patch setuptools