### PR TITLE
deepcopy should not be used with SymPy objects

### DIFF
--- a/python/amici/ode_export.py
+++ b/python/amici/ode_export.py
@@ -1654,9 +1654,11 @@ class ODEModel:
         # Dydz = dydx*dxdz + dydz
 
         # initialize with partial derivative dydz without chain rule
-        self._eqs[name] = copy.deepcopy(
-            self.sym_or_eq(name, f'd{eq}d{var}')
-        )
+        self._eqs[name] = self.sym_or_eq(name, f'd{eq}d{var}')
+        if not isinstance(self._eqs[name], sp.Symbol):
+            # if not a Symbol, create a copy using sympy API
+            # NB deepcopy does not work safely, see sympy issue #7672
+            self._eqs[name] = self._eqs[name].copy()
 
         for chainvar in chainvars:
             if dydx_name is None:

--- a/python/amici/ode_export.py
+++ b/python/amici/ode_export.py
@@ -242,7 +242,7 @@ nobody_functions = [
 sensi_functions = [
     function for function in functions
     if 'const int ip' in functions[function]['signature']
-    and function is not 'sxdot'
+    and function != 'sxdot'
 ]
 # list of multiobs functions
 multiobs_functions = [

--- a/python/amici/sbml_import.py
+++ b/python/amici/sbml_import.py
@@ -13,7 +13,6 @@ import math
 import itertools as itt
 import warnings
 import logging
-import copy
 from typing import Dict, Union, List, Callable, Any, Iterable
 
 from .ode_export import ODEExporter, ODEModel
@@ -1200,7 +1199,7 @@ class SbmlImporter:
             ])
             observable_ids = observables.keys()
         else:
-            observable_values = copy.deepcopy(species_syms)
+            observable_values = species_syms.copy() # prefer sympy's copy over deepcopy, see sympy issue #7672
             observable_ids = [
                 f'x{index}' for index in range(len(species_syms))
             ]


### PR DESCRIPTION
Using `copy.deepcopy` with symbolic objects should be avoided. In particular, it breaks the caching of `Symbols` also in the user's code. See sympy/sympy#7672.
I tried substituting all uses of `deepcopy` with calls to the symbolic object's `copy` method. I believe the spirit of the code is preserved and it seems to work fine on my problem. However, I cannot exclude that some edge cases may have depended on some very specific behaviour of `deepcopy`...