### PR TITLE
Workaround for #1095 - pin sympy to < 1.6 until symbolic code is updated

### DIFF
--- a/.github/workflows/test-petab-test-suite.yml
+++ b/.github/workflows/test-petab-test-suite.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Download and run petab test suite
       run: |
         git clone --depth 1 https://github.com/petab-dev/petab_test_suite \
-          && cd petab_test_suite; pip3 install --upgrade --upgrade-strategy only-if-needed -e .; cd .. \
+          && cd petab_test_suite; pip3 install --upgrade --upgrade-strategy only-if-needed .; cd .. \
           && AMICI_PARALLEL_COMPILE=2 pytest -v \
             --cov-report=xml --cov-append --cov=amici tests/petab_test_suite/
 

--- a/.github/workflows/test-petab-test-suite.yml
+++ b/.github/workflows/test-petab-test-suite.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Download and run petab test suite
       run: |
         git clone --depth 1 https://github.com/petab-dev/petab_test_suite \
-          && cd petab_test_suite; pip3 install -e .; cd .. \
+          && cd petab_test_suite; pip3 install --upgrade-strategy only-if-needed -e .; cd .. \
           && AMICI_PARALLEL_COMPILE=2 pytest -v \
             --cov-report=xml --cov-append --cov=amici tests/petab_test_suite/
 

--- a/.github/workflows/test-petab-test-suite.yml
+++ b/.github/workflows/test-petab-test-suite.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Download and run petab test suite
       run: |
         git clone --depth 1 https://github.com/petab-dev/petab_test_suite \
-          && cd petab_test_suite; pip3 install --upgrade-strategy only-if-needed -e .; cd .. \
+          && cd petab_test_suite; pip3 install --upgrade --upgrade-strategy to-satisfy-only -e .; cd .. \
           && AMICI_PARALLEL_COMPILE=2 pytest -v \
             --cov-report=xml --cov-append --cov=amici tests/petab_test_suite/
 

--- a/.github/workflows/test-petab-test-suite.yml
+++ b/.github/workflows/test-petab-test-suite.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Download and run petab test suite
       run: |
         git clone --depth 1 https://github.com/petab-dev/petab_test_suite \
-          && cd petab_test_suite; pip3 install --upgrade --upgrade-strategy to-satisfy-only -e .; cd .. \
+          && cd petab_test_suite; pip3 install --upgrade --upgrade-strategy only-if-needed -e .; cd .. \
           && AMICI_PARALLEL_COMPILE=2 pytest -v \
             --cov-report=xml --cov-append --cov=amici tests/petab_test_suite/
 

--- a/python/sdist/setup.py
+++ b/python/sdist/setup.py
@@ -202,7 +202,7 @@ def main():
                 'amici_import_petab.py = amici.petab_import:main'
             ]
         },
-        install_requires=['sympy',
+        install_requires=['sympy<=1.5.1',
                           'python-libsbml',
                           'h5py',
                           'pandas',


### PR DESCRIPTION
#1095 