### PR TITLE
Hotfix steadystate sensi allocation

### DIFF
--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -101,7 +101,8 @@ void Solver::setup(const realtype t0, Model *model, const AmiVector &x0,
     initializeLinearSolver(model);
     initializeNonLinearSolver();
 
-    if (sensi >= SensitivityOrder::first && model->nx_solver > 0) {
+    if (sensi >= SensitivityOrder::first &&
+        sensi_meth > SensitivityMethod::none && model->nx_solver > 0) {
         auto plist = model->getParameterList();
         sensInit1(sx0, sdx0);
         if (sensi_meth == SensitivityMethod::forward && !plist.empty()) {

--- a/src/steadystateproblem.cpp
+++ b/src/steadystateproblem.cpp
@@ -334,7 +334,7 @@ std::unique_ptr<Solver> SteadystateProblem::createSteadystateSimSolver(
 {
     /* Create new CVode solver object */
 
-    auto newton_solver = std::unique_ptr<Solver>(solver->clone());
+    auto sim_solver = std::unique_ptr<Solver>(solver->clone());
 
     switch (solver->getLinearSolver()) {
     case LinearSolver::dense:
@@ -347,17 +347,19 @@ std::unique_ptr<Solver> SteadystateProblem::createSteadystateSimSolver(
     }
     if (solver->getSensitivityMethod() != SensitivityMethod::none &&
         model->getSteadyStateSensitivityMode() ==
-            SteadyStateSensitivityMode::simulationFSA)
-        newton_solver->setSensitivityMethod(SensitivityMethod::forward);
-    // need forward to compute sx0
-    else
-        newton_solver->setSensitivityMethod(SensitivityMethod::none);
-
+        SteadyStateSensitivityMode::simulationFSA) {
+        // need forward to compute sx0
+        sim_solver->setSensitivityMethod(SensitivityMethod::forward);
+    }
+    else {
+        sim_solver->setSensitivityMethod(SensitivityMethod::none);
+        sim_solver->setSensitivityOrder(SensitivityOrder::none);
+    }
     /* use x and sx as dummies for dx and sdx
      (they wont get touched in a CVodeSolver) */
-    newton_solver->setup(model->t0(), model, x, x, sx, sx);
+    sim_solver->setup(model->t0(), model, x, x, sx, sx);
 
-    return newton_solver;
+    return sim_solver;
 }
 
 void SteadystateProblem::getAdjointUpdates(Model &model,


### PR DESCRIPTION
Ii seems like in steady state forward simulation, space for forward sensis has always been allocated (is sensitivityOrder was not set to none), even those weren't used (due to using the newton_only option). This should fix it.