### PR TITLE
Allow model time in observable formulas

### DIFF
--- a/python/amici/petab_import.py
+++ b/python/amici/petab_import.py
@@ -474,7 +474,7 @@ def import_model(sbml_model: Union[str, 'libsbml.Model'],
                            key=lambda symbol: symbol.name)
         for free_sym in free_syms:
             sym = str(free_sym)
-            if sbml_model.getElementBySId(sym) is None:
+            if sbml_model.getElementBySId(sym) is None and sym != 'time':
                 output_parameters[sym] = None
     logger.debug(f"Adding output parameters to model: {output_parameters}")
     for par in output_parameters.keys():


### PR DESCRIPTION
If https://github.com/PEtab-dev/PEtab/pull/445 is merged, then the model time will be allowed in the formulas for PEtab observables. I do not see (but correct me if I am wrong) that there should be any technical reason against allowing this also in AMICI.

This small change seems to be all that is needed to load the resulting PEtab files with AMICI. 