### PR TITLE
Remove workaround for icpc std::regex issue

### DIFF
--- a/src/model.cpp
+++ b/src/model.cpp
@@ -72,17 +72,7 @@ static int setValueByIdRegex(std::vector<std::string> const &ids,
                              std::string const &regex,
                              const char *variable_name, const char *id_name) {
     try {
-        /* For unknown reasons, the Intel compiler fails to compile patterns
-         * such as p[\d]+, which work with g++ and clang.
-         * Using std::regex_constants::extended fixes Intel issues, but g++
-         * seems to not match the pattern correctly.
-         * This is the best solution I was able to come up with...
-         */
-#ifdef __INTEL_COMPILER
-        std::regex pattern(regex, std::regex_constants::extended);
-#else
         std::regex pattern(regex);
-#endif
         int n_found = 0;
         for (const auto &id : ids) {
             if (std::regex_match(id, pattern)) {


### PR DESCRIPTION
Now works as expected, but workaround fails.

Closes #1133