### PR TITLE
Speedup modelname.cpp compilation by using char arrays instead of std…

### DIFF
--- a/.github/workflows/test-large-model.yml
+++ b/.github/workflows/test-large-model.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - develop
       - master
-      - feature_fast_index_compilation
+      - feature_speedup_compilation
 
   pull_request:
     branches:

--- a/src/model.ODE_template.cpp
+++ b/src/model.ODE_template.cpp
@@ -5,35 +5,35 @@ namespace amici {
 
 namespace model_TPL_MODELNAME {
 
-std::array<std::string, TPL_NP> parameterNames = {
+std::array<const char*, TPL_NP> parameterNames = {
     TPL_PARAMETER_NAMES_INITIALIZER_LIST
 };
 
-std::array<std::string, TPL_NK> fixedParameterNames = {
+std::array<const char*, TPL_NK> fixedParameterNames = {
     TPL_FIXED_PARAMETER_NAMES_INITIALIZER_LIST
 };
 
-std::array<std::string, TPL_NX_RDATA> stateNames = {
+std::array<const char*, TPL_NX_RDATA> stateNames = {
     TPL_STATE_NAMES_INITIALIZER_LIST
 };
 
-std::array<std::string, TPL_NY> observableNames = {
+std::array<const char*, TPL_NY> observableNames = {
     TPL_OBSERVABLE_NAMES_INITIALIZER_LIST
 };
 
-std::array<std::string, TPL_NP> parameterIds = {
+std::array<const char*, TPL_NP> parameterIds = {
     TPL_PARAMETER_IDS_INITIALIZER_LIST
 };
 
-std::array<std::string, TPL_NK> fixedParameterIds = {
+std::array<const char*, TPL_NK> fixedParameterIds = {
     TPL_FIXED_PARAMETER_IDS_INITIALIZER_LIST
 };
 
-std::array<std::string, TPL_NX_RDATA> stateIds = {
+std::array<const char*, TPL_NX_RDATA> stateIds = {
     TPL_STATE_IDS_INITIALIZER_LIST
 };
 
-std::array<std::string, TPL_NY> observableIds = {
+std::array<const char*, TPL_NY> observableIds = {
     TPL_OBSERVABLE_IDS_INITIALIZER_LIST
 };
 

--- a/src/model_header.ODE_template.h
+++ b/src/model_header.ODE_template.h
@@ -14,14 +14,14 @@ class Solver;
 
 namespace model_TPL_MODELNAME {
 
-extern std::array<std::string, TPL_NP> parameterNames;
-extern std::array<std::string, TPL_NK> fixedParameterNames;
-extern std::array<std::string, TPL_NX_RDATA> stateNames;
-extern std::array<std::string, TPL_NY> observableNames;
-extern std::array<std::string, TPL_NP> parameterIds;
-extern std::array<std::string, TPL_NK> fixedParameterIds;
-extern std::array<std::string, TPL_NX_RDATA> stateIds;
-extern std::array<std::string, TPL_NY> observableIds;
+extern std::array<const char*, TPL_NP> parameterNames;
+extern std::array<const char*, TPL_NK> fixedParameterNames;
+extern std::array<const char*, TPL_NX_RDATA> stateNames;
+extern std::array<const char*, TPL_NY> observableNames;
+extern std::array<const char*, TPL_NP> parameterIds;
+extern std::array<const char*, TPL_NK> fixedParameterIds;
+extern std::array<const char*, TPL_NX_RDATA> stateIds;
+extern std::array<const char*, TPL_NY> observableIds;
 
 
 extern void J_TPL_MODELNAME(realtype *J, const realtype t, const realtype *x,


### PR DESCRIPTION
…::string

Follow-up to #1105

tested with icpc (ICC) 19.0.5.281 20190815; -O3:

> Elapsed (wall clock) time (h:mm:ss or m:ss): 0:01.17
> Maximum resident set size (kbytes): 249984

before, terminated at:
> Elapsed (wall clock) time (h:mm:ss or m:ss): 2:19:33
> Maximum resident set size (kbytes): 443383356
> Fatal compilation error: Out of memory asking for 18446744072184442880.