### PR TITLE
Fix and cleanup extension import logic

### DIFF
--- a/python/amici/__init__.py
+++ b/python/amici/__init__.py
@@ -81,14 +81,15 @@ def _imported_from_setup() -> bool:
     # in case we are imported from setup.py, this will be the AMICI package
     # root directory (otherwise it is most likely the Python library directory,
     # we are not interested in)
-    package_root = os.path.dirname(os.path.dirname(__file__))
+    package_root = os.path.realpath(os.path.dirname(os.path.dirname(__file__)))
 
     for frame in getouterframes(currentframe()):
         # Need to compare the full path, in case a user tries to import AMICI
         # from a module `*setup.py`. Will still cause trouble if some package
         # requires the AMICI extension during its installation, but seems
         # unlikely...
-        if frame.filename == os.path.join(package_root, 'setup.py'):
+        frame_path = os.path.realpath(os.path.expanduser(frame.filename))
+        if frame_path == os.path.join(package_root, 'setup.py'):
             return True
 
     return False

--- a/python/amici/__init__.py
+++ b/python/amici/__init__.py
@@ -61,8 +61,7 @@ def _get_commit_hash():
         (
             file for file in [
                 os.path.join(basedir, '.git', 'FETCH_HEAD'),
-                os.path.join(basedir, '.git', 'ORIG_HEAD'),
-            ]
+                os.path.join(basedir, '.git', 'ORIG_HEAD'), ]
             if os.path.isfile(file)
         ),
         None
@@ -125,25 +124,29 @@ with open(os.path.join(amici_path, 'version.txt')) as f:
 
 __commit__ = _get_commit_hash()
 
-
 # Import SWIG module and swig-dependent submodules if required and available
-if not _imported_from_setup() and has_clibs:
-    if hdf5_enabled:
-        from . import amici
-        from .amici import *
-    else:
-        from . import amici_without_hdf5 as amici
-        from .amici_without_hdf5 import *
+if not _imported_from_setup():
+    if has_clibs:
+        if hdf5_enabled:
+            from . import amici
+            from .amici import *
+        else:
+            from . import amici_without_hdf5 as amici
+            from .amici_without_hdf5 import *
 
-    # These module require the swig interface and other dependencies
-    from .numpy import ReturnDataView, ExpDataView
-    from .pandas import getEdataFromDataFrame, \
-        getDataObservablesAsDataFrame, getSimulationObservablesAsDataFrame, \
-        getSimulationStatesAsDataFrame, getResidualsAsDataFrame
+        # These module require the swig interface and other dependencies
+        from .numpy import ReturnDataView, ExpDataView
+        from .pandas import (
+            getEdataFromDataFrame,
+            getDataObservablesAsDataFrame,
+            getSimulationObservablesAsDataFrame,
+            getSimulationStatesAsDataFrame,
+            getResidualsAsDataFrame
+        )
 
-# These modules don't require the swig interface
-from .sbml_import import SbmlImporter, assignmentRules2observables
-from .ode_export import ODEModel, ODEExporter
+    # These modules don't require the swig interface
+    from .sbml_import import SbmlImporter, assignmentRules2observables
+    from .ode_export import ODEModel, ODEExporter
 
 
 def runAmiciSimulation(
@@ -257,6 +260,7 @@ def writeSolverSettingsToHDF5(
 
 class add_path:
     """Context manager for temporarily changing PYTHONPATH"""
+
     def __init__(self, path: str):
         self.path: str = path
 
@@ -290,6 +294,5 @@ def import_model_module(module_name: str,
             # reload, because may just have been created
             importlib.reload(sys.modules[module_name])
             return sys.modules[module_name]
-
 
         return importlib.import_module(module_name)

--- a/python/amici/custom_commands.py
+++ b/python/amici/custom_commands.py
@@ -199,23 +199,10 @@ class AmiciBuildExt(build_ext):
         no_clibs |= 'install' in self.distribution.command_obj \
                     and self.get_finalized_command('install').no_clibs
 
-        # remove swig-python-wrapper files
-        unused_swig_wrappers = {'amici/amici_wrap.cxx',
-                                'amici/amici_wrap_without_hdf5.cxx'}
-        if not no_clibs:
-            # check for used c++ interface files
-            for ext in self.extensions:
-                unused_swig_wrappers -= set(ext.sources)
+        lib_dir = "" if self.inplace \
+            else self.get_finalized_command('build_py').build_lib
 
-        if 'amici/amici_wrap.cxx' in unused_swig_wrappers:
-            unused_swig_wrappers.add('amici/amici.py')
-        if 'amici/amici_wrap_without_hdf5.cxx' in unused_swig_wrappers:
-            unused_swig_wrappers.add('amici/amici_without_hdf5.py')
-
-        for filename in unused_swig_wrappers:
-            with contextlib.suppress(FileNotFoundError):
-                log.info(f"Removing unused SWIG wrapper {filename}")
-                os.remove(filename)
+        remove_swig_wrappers(self.extensions, no_clibs, lib_dir)
 
         if no_clibs:
             # Nothing to build
@@ -364,3 +351,26 @@ def set_compiler_specific_extension_options(
         except AttributeError:
             # No compiler-specific options set
             pass
+
+
+def remove_swig_wrappers(extensions: 'setuptools.Extension',
+                         no_clibs: bool, lib_dir: str) -> None:
+    """Remove swig wrapper files not needed by the built extensions"""
+
+    # remove swig-python-wrapper files
+    unused_swig_wrappers = {'amici/amici_wrap.cxx',
+                            'amici/amici_wrap_without_hdf5.cxx'}
+    if not no_clibs:
+        # check for used c++ interface files
+        for ext in extensions:
+            unused_swig_wrappers -= set(ext.sources)
+
+    if 'amici/amici_wrap.cxx' in unused_swig_wrappers:
+        unused_swig_wrappers.add('amici/amici.py')
+    if 'amici/amici_wrap_without_hdf5.cxx' in unused_swig_wrappers:
+        unused_swig_wrappers.add('amici/amici_without_hdf5.py')
+
+    for filename in unused_swig_wrappers:
+        with contextlib.suppress(FileNotFoundError):
+            log.info(f"Removing unused SWIG wrapper {os.path.realpath(filename)}")
+            os.remove(os.path.join(lib_dir, filename))

--- a/python/amici/setuptools.py
+++ b/python/amici/setuptools.py
@@ -15,6 +15,7 @@ from .swig import find_swig, get_swig_version
 
 try:
     import pkgconfig  # optional
+
     # pkgconfig python module might be installed without pkg-config binary
     # being available
     pkgconfig.exists('somePackageName')
@@ -69,7 +70,7 @@ def get_blas_config() -> PackageInfo:
             blaspkgcfg['extra_link_args'].extend(
                 shlex.split(os.environ['MKL_LIB'])
             )
-        blaspkgcfg['define_macros'].append(('AMICI_BLAS_MKL', None),)
+        blaspkgcfg['define_macros'].append(('AMICI_BLAS_MKL', None), )
         return blaspkgcfg
 
     # Try pkgconfig
@@ -193,8 +194,8 @@ def add_coverage_flags_if_required(cxx_flags: List[str],
     if 'ENABLE_GCOV_COVERAGE' in os.environ and \
             os.environ['ENABLE_GCOV_COVERAGE'] == 'TRUE':
         log.info("ENABLE_GCOV_COVERAGE was set to TRUE."
-              " Building AMICI with coverage symbols.")
-        cxx_flags.extend(['-g', '-O0',  '--coverage'])
+                 " Building AMICI with coverage symbols.")
+        cxx_flags.extend(['-g', '-O0', '--coverage'])
         linker_flags.extend(['--coverage', '-g'])
 
 
@@ -213,7 +214,7 @@ def add_debug_flags_if_required(cxx_flags: List[str],
     if 'ENABLE_AMICI_DEBUGGING' in os.environ \
             and os.environ['ENABLE_AMICI_DEBUGGING'] == 'TRUE':
         log.info("ENABLE_AMICI_DEBUGGING was set to TRUE."
-              " Building AMICI with debug symbols.")
+                 " Building AMICI with debug symbols.")
         cxx_flags.extend(['-g', '-O0'])
         linker_flags.extend(['-g'])
 

--- a/python/sdist/setup.py
+++ b/python/sdist/setup.py
@@ -137,7 +137,8 @@ def main():
 
     # Readme as long package description to go on PyPi
     # (https://pypi.org/project/amici/)
-    with open("README.md", "r", encoding="utf-8") as fh:
+    with open(os.path.join(os.path.dirname(__file__), "README.md"),
+              "r", encoding="utf-8") as fh:
         long_description = fh.read()
 
     # Build shared object


### PR DESCRIPTION
* Don't import AMICI extension when amici is imported from setup.py (Closes #1140)

* Cleanup import logic: Removing unused SWIG-generated files and import based on existance of remaining ones

* Avoid unnecessary imports when called from setup.py