### PR TITLE
Correctly parse piecewise functions in rules

### DIFF
--- a/python/amici/sbml_import.py
+++ b/python/amici/sbml_import.py
@@ -1030,7 +1030,7 @@ class SbmlImporter:
                 for nested_rule in rules:
 
                     nested_formula = sp.sympify(
-                        sbml.formulaToL3String(nested_rule.getMath()),
+                        _parse_logical_operators(sbml.formulaToL3String(nested_rule.getMath())),
                         locals=self.local_symbols).subs(variable, formula)
                     nested_formula = _parse_special_functions(nested_formula)
                     _check_unsupported_functions(nested_formula, 'Rule')
@@ -1160,10 +1160,13 @@ class SbmlImporter:
             for s in formula.free_symbols:
                 r = self.sbml.getAssignmentRuleByVariable(str(s))
                 if r is not None:
-                    formula = formula.replace(s, sp.sympify(
-                        sbml.formulaToL3String(r.getMath()),
-                        locals=self.local_symbols
-                    ))
+                    rule_formula = _parse_logical_operators(
+                        sbml.formulaToL3String(r.getMath()))
+                    rule_formula = sp.sympify(
+                        rule_formula, locals=self.local_symbols)
+                    rule_formula = _parse_special_functions(rule_formula)
+                    _check_unsupported_functions(rule_formula, 'Rule')
+                    formula = formula.replace(s, rule_formula)
             return formula
 
         # add user-provided observables or make all species, and compartments

--- a/python/amici/sbml_import.py
+++ b/python/amici/sbml_import.py
@@ -1032,13 +1032,16 @@ class SbmlImporter:
                     nested_formula = sp.sympify(
                         sbml.formulaToL3String(nested_rule.getMath()),
                         locals=self.local_symbols).subs(variable, formula)
+                    nested_formula = _parse_special_functions(nested_formula)
+                    _check_unsupported_functions(nested_formula, 'Rule')
 
                     nested_rule_math_ml = mathml(nested_formula)
                     nested_rule_math_ml_ast_node = sbml.readMathMLFromString(nested_rule_math_ml)
 
                     if nested_rule_math_ml_ast_node is None:
                         raise SBMLException(f'Formula {sbml.formulaToL3String(nested_rule.getMath())}'
-                                            f' cannot be parsed to valid MathML by SymPy!')
+                                            f' cannot be correctly read by SymPy'
+                                            f' or cannot be converted to valid MathML by SymPy!')
 
                     elif nested_rule.setMath(nested_rule_math_ml_ast_node) != sbml.LIBSBML_OPERATION_SUCCESS:
                         raise SBMLException(f'Formula {sbml.formulaToL3String(nested_rule.getMath())}'


### PR DESCRIPTION
If a piecewise function is present inside a SBML assignment rule, sometimes (probably depending on rule ordering) it may not be correctly parsed. Use of `_parse_special_functions` after all instances of reading rule formulas solves this problem.

As a note, in my project (which makes heavy use of nested rules) most of the time inside `_process_rules` is spent sympifying formulas or converting them to MathML in order to be written back into the SBML document. A possible idea to speed up things would be to convert all rules to SymPy formulas at the beginning and then operate only on the SymPy objects without touching the SBML anymore.