### PR TITLE
Reduce memory consumption for storing simulation states

### DIFF
--- a/include/amici/forwardproblem.h
+++ b/include/amici/forwardproblem.h
@@ -239,7 +239,11 @@ class ForwardProblem {
      * @return state
      */
     const SimulationState &getSimulationStateTimepoint(int it) const {
-        return timepoint_states.find(timepoints.at(it))->second;
+        if (timepoints.at(it) == initial_state.t) {
+            return getInitialSimulationState;
+        } else {
+            return timepoint_states.find(timepoints.at(it))->second;
+        }
     };
 
     /**

--- a/include/amici/forwardproblem.h
+++ b/include/amici/forwardproblem.h
@@ -395,9 +395,6 @@ class ForwardProblem {
     /** current time */
     realtype t;
 
-    /** number of timepoints */
-    std::vector<realtype> timepoints;
-
     /**
      * @brief Array of flags indicating which root has beend found.
      *

--- a/include/amici/forwardproblem.h
+++ b/include/amici/forwardproblem.h
@@ -239,7 +239,7 @@ class ForwardProblem {
      * @return state
      */
     const SimulationState &getSimulationStateTimepoint(int it) const {
-        return timepoint_states[timepoints.at(it)];
+        return timepoint_states.find(timepoints.at(it))->second;
     };
 
     /**
@@ -406,7 +406,7 @@ class ForwardProblem {
     std::map<realtype, SimulationState> timepoint_states;
 
     /** simulation state history at events*/
-    std::map<SimulationState> event_states;
+    std::vector<SimulationState> event_states;
 
     /** simulation state after initialization*/
     SimulationState initial_state;

--- a/include/amici/forwardproblem.h
+++ b/include/amici/forwardproblem.h
@@ -212,8 +212,8 @@ class ForwardProblem {
      * @brief Returns maximal time point index for which simulations are available
      * @return index
      */
-    int getTimepointCounter() const {
-        return static_cast<int>(timepoints.size() - 1);
+    realtype getFinalTime() const {
+        return final_state.t;
     }
 
     /**
@@ -239,10 +239,10 @@ class ForwardProblem {
      * @return state
      */
     const SimulationState &getSimulationStateTimepoint(int it) const {
-        if (timepoints.at(it) == initial_state.t) {
+        if (model->getTimepoint(it) == initial_state.t) {
             return getInitialSimulationState();
         } else {
-            return timepoint_states.find(timepoints.at(it))->second;
+            return timepoint_states.find(model->getTimepoint(it))->second;
         }
     };
 

--- a/include/amici/forwardproblem.h
+++ b/include/amici/forwardproblem.h
@@ -209,8 +209,8 @@ class ForwardProblem {
     }
 
     /**
-     * @brief Returns maximal time point index for which simulations are available
-     * @return index
+     * @brief Returns final time point for which simulations are available
+     * @return time point
      */
     realtype getFinalTime() const {
         return final_state.t;
@@ -239,11 +239,9 @@ class ForwardProblem {
      * @return state
      */
     const SimulationState &getSimulationStateTimepoint(int it) const {
-        if (model->getTimepoint(it) == initial_state.t) {
+        if (model->getTimepoint(it) == initial_state.t)
             return getInitialSimulationState();
-        } else {
-            return timepoint_states.find(model->getTimepoint(it))->second;
-        }
+        return timepoint_states.find(model->getTimepoint(it))->second;
     };
 
     /**

--- a/include/amici/forwardproblem.h
+++ b/include/amici/forwardproblem.h
@@ -213,7 +213,7 @@ class ForwardProblem {
      * @return index
      */
     int getTimepointCounter() const {
-        return static_cast<int>(timepoint_states.size() - 1);
+        return static_cast<int>(timepoints.size() - 1);
     }
 
     /**
@@ -239,7 +239,7 @@ class ForwardProblem {
      * @return state
      */
     const SimulationState &getSimulationStateTimepoint(int it) const {
-        return timepoint_states.at(it);
+        return timepoint_states[timepoints.at(it)];
     };
 
     /**
@@ -391,6 +391,9 @@ class ForwardProblem {
     /** current time */
     realtype t;
 
+    /** number of timepoints */
+    std::vector<realtype> timepoints;
+
     /**
      * @brief Array of flags indicating which root has beend found.
      *
@@ -400,10 +403,10 @@ class ForwardProblem {
     std::vector<int> rootsfound;
 
     /** simulation states history at timepoints  */
-    std::vector<SimulationState> timepoint_states;
+    std::map<realtype, SimulationState> timepoint_states;
 
     /** simulation state history at events*/
-    std::vector<SimulationState> event_states;
+    std::map<SimulationState> event_states;
 
     /** simulation state after initialization*/
     SimulationState initial_state;

--- a/include/amici/forwardproblem.h
+++ b/include/amici/forwardproblem.h
@@ -240,7 +240,7 @@ class ForwardProblem {
      */
     const SimulationState &getSimulationStateTimepoint(int it) const {
         if (timepoints.at(it) == initial_state.t) {
-            return getInitialSimulationState;
+            return getInitialSimulationState();
         } else {
             return timepoint_states.find(timepoints.at(it))->second;
         }

--- a/python/tests/test_preequilibration.py
+++ b/python/tests/test_preequilibration.py
@@ -294,7 +294,7 @@ def test_equilibration_methods_with_adjoints(preeq_fixture):
     for setting in settings:
         # unpack, solver settings
         equil_meth, sensi_meth = setting
-        model.SteadyStateSensitivityMethod = equil_meth
+        model.setSteadyStateSensitivityMode(equil_meth)
         solver.setSensitivityMethod(sensi_meth)
         solver.setNewtonMaxSteps(0)
 
@@ -340,7 +340,7 @@ def test_newton_solver_equilibration(preeq_fixture):
         # set sensi method
         sensi_meth = amici.SensitivityMethod.forward
         solver.setSensitivityMethod(sensi_meth)
-        solver.SteadyStateSensitivityMethod = equil_meth
+        model.setSteadyStateSensitivityMode(equil_meth)
         if equil_meth == amici.SteadyStateSensitivityMode.newtonOnly:
             solver.setNewtonMaxSteps(10)
         else:
@@ -368,8 +368,8 @@ def test_newton_solver_equilibration(preeq_fixture):
     solver.setLinearSolver(amici.LinearSolver.SPBCG)
     solver.setSensitivityMethod(amici.SensitivityMethod.adjoint)
     solver.setSensitivityOrder(amici.SensitivityOrder.first)
-    solver.SteadyStateSensitivityMethod = \
-        amici.SteadyStateSensitivityMode.newtonOnly
+    model.setSteadyStateSensitivityMode(
+        amici.SteadyStateSensitivityMode.newtonOnly)
     solver.setNewtonMaxSteps(10)
     solver.setNewtonMaxLinearSteps(10)
     rdata_spbcg = amici.runAmiciSimulation(model, solver, edata)

--- a/src/forwardproblem.cpp
+++ b/src/forwardproblem.cpp
@@ -290,8 +290,8 @@ void ForwardProblem::storeEvent() {
 void ForwardProblem::handleDataPoint(int it) {
     /* We only store the simulation state if it's not the initial state, as the
        initial state is stored anyway and we want to avoid storing it twice */
-    if (t != model->t0())
-        timepoint_states.insert(std::make_pair(t, getSimulationState()));
+    if (t != model->t0() && timepoint_states.count(t) > 0)
+        timepoint_states[t] = getSimulationState();
     /* store diagnosis information for debugging */
     solver->storeDiagnosis();
 }

--- a/src/forwardproblem.cpp
+++ b/src/forwardproblem.cpp
@@ -288,7 +288,8 @@ void ForwardProblem::storeEvent() {
 }
 
 void ForwardProblem::handleDataPoint(int it) {
-    timepoint_states.push_back(getSimulationState());
+    timepoints.push_back(getTime());
+    timepoint_states.insert(std::make_pair(getTime(), getSimulationState()));
     solver->storeDiagnosis();
 }
 
@@ -313,7 +314,7 @@ void ForwardProblem::getAdjointUpdates(Model &model,
             return;
         model.getAdjointStateObservableUpdate(
             slice(dJydx, it, model.nx_solver * model.nJ), it,
-            timepoint_states.at(it).x, edata
+            timepoint_states[timepoints.at(it)].x, edata
         );
     }
 }

--- a/src/forwardproblem.cpp
+++ b/src/forwardproblem.cpp
@@ -288,12 +288,12 @@ void ForwardProblem::storeEvent() {
 }
 
 void ForwardProblem::handleDataPoint(int it) {
-    timepoints.push_back(getTime());
-    solver->storeDiagnosis();
     /* We only store the simulation state if it's not the initial state, as the
        initial state is stored anyway and we want to avoid storing it twice */
     if (t != model->t0())
         timepoint_states.insert(std::make_pair(t, getSimulationState()));
+    /* store diagnosis information for debugging */
+    solver->storeDiagnosis();
 }
 
 void ForwardProblem::applyEventBolus() {

--- a/src/forwardproblem.cpp
+++ b/src/forwardproblem.cpp
@@ -314,7 +314,7 @@ void ForwardProblem::getAdjointUpdates(Model &model,
             return;
         model.getAdjointStateObservableUpdate(
             slice(dJydx, it, model.nx_solver * model.nJ), it,
-            timepoint_states[timepoints.at(it)].x, edata
+            (timepoint_states.find(timepoints.at(it))->second).x, edata
         );
     }
 }

--- a/src/forwardproblem.cpp
+++ b/src/forwardproblem.cpp
@@ -290,7 +290,7 @@ void ForwardProblem::storeEvent() {
 void ForwardProblem::handleDataPoint(int it) {
     /* We only store the simulation state if it's not the initial state, as the
        initial state is stored anyway and we want to avoid storing it twice */
-    if (t != model->t0() && timepoint_states.count(t) > 0)
+    if (t != model->t0() && timepoint_states.count(t) == 0)
         timepoint_states[t] = getSimulationState();
     /* store diagnosis information for debugging */
     solver->storeDiagnosis();

--- a/src/forwardproblem.cpp
+++ b/src/forwardproblem.cpp
@@ -289,8 +289,11 @@ void ForwardProblem::storeEvent() {
 
 void ForwardProblem::handleDataPoint(int it) {
     timepoints.push_back(getTime());
-    timepoint_states.insert(std::make_pair(getTime(), getSimulationState()));
     solver->storeDiagnosis();
+    /* We only store the simulation state if it's not the initial state, as the
+       initial state is stored anyway and we want to avoid storing it twice */
+    if (t != model->t0())
+        timepoint_states.insert(std::make_pair(t, getSimulationState()));
 }
 
 void ForwardProblem::applyEventBolus() {
@@ -314,7 +317,7 @@ void ForwardProblem::getAdjointUpdates(Model &model,
             return;
         model.getAdjointStateObservableUpdate(
             slice(dJydx, it, model.nx_solver * model.nJ), it,
-            (timepoint_states.find(timepoints.at(it))->second).x, edata
+            getSimulationStateTimepoint(it).x, edata
         );
     }
 }

--- a/src/rdata.cpp
+++ b/src/rdata.cpp
@@ -251,14 +251,17 @@ void ReturnData::processForwardProblem(ForwardProblem const &fwd, Model &model,
     }
 
     // process timpoint data
-    for (int it = 0; it <= fwd.getTimepointCounter(); it++) {
-        readSimulationState(fwd.getSimulationStateTimepoint(it), model);
-        getDataOutput(it, model, edata);
+    realtype tf = fwd.getFinalTime();
+    for (int it = 0; it < model.nt(); it++) {
+        if (model.getTimepoint(it) <= tf) {
+            readSimulationState(fwd.getSimulationStateTimepoint(it), model);
+            getDataOutput(it, model, edata);
+        } else {
+            // check for integration failure but consider postequilibration
+            if (!std::isinf(model.getTimepoint(it)))
+                invalidate(it);
+        }
     }
-    // check for integration failure but consider postequilibration
-    for (int it = fwd.getTimepointCounter() + 1; it < nt; it++)
-        if (!std::isinf(model.getTimepoint(it)))
-            invalidate(it);
 
     // process event data
     if (nz > 0) {


### PR DESCRIPTION
Closes #1150 
The simulation states are no longer stored as a vector but as a map, which avoids storing of replicates and reduces memory consumption, if many timepoint replicates are used and sx is large.
Moreover, the initial state is stored only once, if model->t0() is also a simulation time point.