### PR TITLE
 PySB-based PEtab problems

### DIFF
--- a/.github/workflows/test-petab-test-suite.yml
+++ b/.github/workflows/test-petab-test-suite.yml
@@ -41,6 +41,7 @@ jobs:
       run: |
         scripts/buildBNGL.sh
     - run: |
+        echo "::set-env name=AMICI_DIR::$(pwd)"
         echo "::add-path::${HOME}/.local/bin/"
         echo "::add-path::${GITHUB_WORKSPACE}/tests/performance/"
         echo "::set-env name=BNGPATH::${AMICI_DIR}/ThirdParty/BioNetGen-2.3.2"

--- a/.github/workflows/test-petab-test-suite.yml
+++ b/.github/workflows/test-petab-test-suite.yml
@@ -41,9 +41,9 @@ jobs:
       run: |
         scripts/buildBNGL.sh
     - run: |
-        echo "::add-path::${HOME}/.local/bin/"
-        echo "::add-path::${GITHUB_WORKSPACE}/tests/performance/"
-        echo "::set-env name=BNGPATH::${GITHUB_WORKSPACE}/ThirdParty/BioNetGen-2.3.2"
+        echo ::add-path::${HOME}/.local/bin/
+        echo ::add-path::${GITHUB_WORKSPACE}/tests/performance/
+        echo ::set-env name=BNGPATH::${GITHUB_WORKSPACE}/ThirdParty/BioNetGen-2.3.2
     # install AMICI
     - name: Install python package
       run: |

--- a/.github/workflows/test-petab-test-suite.yml
+++ b/.github/workflows/test-petab-test-suite.yml
@@ -55,7 +55,7 @@ jobs:
       run: |
         git clone --depth 1 https://github.com/FFroehlich/petab_test_suite \
           && source ./build/venv/bin/activate \
-          && cd petab_test_suite; git checkout pysb; pip3 install -e .; cd .. \
+          && cd petab_test_suite; git fetch; git checkout pysb; pip3 install -e .; cd .. \
           && AMICI_PARALLEL_COMPILE=2 pytest -v \
             --cov-report=xml --cov-append --cov=amici tests/petab_test_suite/
 #      run: |

--- a/.github/workflows/test-petab-test-suite.yml
+++ b/.github/workflows/test-petab-test-suite.yml
@@ -20,59 +20,58 @@ jobs:
       ENABLE_GCOV_COVERAGE: TRUE
 
     steps:
-    - uses: actions/checkout@master
-      with:
-        fetch-depth: 20
+      - uses: actions/checkout@master
+        with:
+          fetch-depth: 20
 
-    # install dependencies
-    - name: apt
-      run: |
-        sudo apt-get update \
-          && sudo apt-get install -y \
-          swig3.0 \
-          libatlas-base-dev \
-          python3-venv
-    - name: pip
-      run: |
-        pip3 install --upgrade --user wheel \
-          && pip3 install --upgrade --user setuptools
-    - run: pip3 install pytest shyaml pytest-cov pysb petab
-    - name: Build BNGL
-      run: |
-        scripts/buildBNGL.sh
-    - run: |
-        echo ::add-path::${HOME}/.local/bin/
-        echo ::add-path::${GITHUB_WORKSPACE}/tests/performance/
-        echo ::set-env name=BNGPATH::${GITHUB_WORKSPACE}/ThirdParty/BioNetGen-2.3.2
-    # install AMICI
-    - name: Install python package
-      run: |
-        scripts/installAmiciSource.sh
+      # install dependencies
+      - name: apt
+        run: |
+          sudo apt-get update \
+            && sudo apt-get install -y \
+            swig3.0 \
+            libatlas-base-dev \
+            python3-venv
 
-    - name: Run PEtab-related unit tests
-      run: |
-        source ./build/venv/bin/activate \
-          && pytest --cov-report=xml --cov=./ python/tests/test_*petab*.py
+      - name: pip
+        run: |
+          pip3 install --upgrade --user wheel \
+            && pip3 install --upgrade --user setuptools
+      - run: pip3 install pytest shyaml pytest-cov pysb petab
 
-    # retrieve test models
-    - name: Download and run petab test suite
-      run: |
-        git clone --depth 1  --branch pysb https://github.com/FFroehlich/petab_test_suite \
-          && source ./build/venv/bin/activate \
-          && cd petab_test_suite && pip3 install -e . && cd .. \
-          && AMICI_PARALLEL_COMPILE=2 pytest -v \
-            --cov-report=xml --cov-append --cov=amici tests/petab_test_suite/
-#      run: |
-#          git clone --depth 1 https://github.com/petab-dev/petab_test_suite \
-#          && source ./build/venv/bin/activate \
-#          && cd petab_test_suite; pip3 install -e .; cd .. \
-#          && AMICI_PARALLEL_COMPILE=2 pytest -v \
-#            --cov-report=xml --cov-append --cov=amici tests/petab_test_suite/
+      - name: Build BNGL
+        run: |
+          scripts/buildBNGL.sh
 
-    - name: Codecov
-      uses: codecov/codecov-action@v1
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage.xml
-        flags: petab
-        fail_ci_if_error: true
+      - run: |
+          echo ::add-path::${HOME}/.local/bin/
+          echo ::add-path::${GITHUB_WORKSPACE}/tests/performance/
+          echo ::set-env name=BNGPATH::${GITHUB_WORKSPACE}/ThirdParty/BioNetGen-2.3.2
+
+      # install AMICI
+      - name: Install python package
+        run: |
+          scripts/installAmiciSource.sh
+
+      - name: Run PEtab-related unit tests
+        run: |
+          source ./build/venv/bin/activate \
+            && pytest --cov-report=xml --cov=./ python/tests/test_*petab*.py
+
+      # retrieve test models
+      - name: Download and run petab test suite
+        # git clone --depth 1 https://github.com/petab-dev/petab_test_suite
+        run: |
+          git clone --depth 1  --branch pysb https://github.com/FFroehlich/petab_test_suite \
+            && source ./build/venv/bin/activate \
+            && cd petab_test_suite && pip3 install -e . && cd .. \
+            && AMICI_PARALLEL_COMPILE=2 pytest -v \
+              --cov-report=xml --cov-append --cov=amici tests/petab_test_suite/
+
+      - name: Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./coverage.xml
+          flags: petab
+          fail_ci_if_error: true

--- a/.github/workflows/test-petab-test-suite.yml
+++ b/.github/workflows/test-petab-test-suite.yml
@@ -41,8 +41,9 @@ jobs:
       run: |
         scripts/buildBNGL.sh
     - run: |
-        echo ::add-path::${HOME}/.local/bin/
-        echo ::add-path::${GITHUB_WORKSPACE}/tests/performance/
+        echo "::add-path::${HOME}/.local/bin/"
+        echo "::add-path::${GITHUB_WORKSPACE}/tests/performance/"
+        echo "::set-env name=BNGPATH::${AMICI_DIR}/ThirdParty/BioNetGen-2.3.2"
     # install AMICI
     - name: Install python package
       run: |

--- a/.github/workflows/test-petab-test-suite.yml
+++ b/.github/workflows/test-petab-test-suite.yml
@@ -53,9 +53,9 @@ jobs:
     # retrieve test models
     - name: Download and run petab test suite
       run: |
-        git clone --depth 1 https://github.com/FFroehlich/petab_test_suite \
+        git clone --depth 1  --branch pysb https://github.com/FFroehlich/petab_test_suite \
           && source ./build/venv/bin/activate \
-          && cd petab_test_suite; git fetch; git checkout pysb; pip3 install -e .; cd .. \
+          && cd petab_test_suite && pip3 install -e . && cd .. \
           && AMICI_PARALLEL_COMPILE=2 pytest -v \
             --cov-report=xml --cov-append --cov=amici tests/petab_test_suite/
 #      run: |

--- a/.github/workflows/test-petab-test-suite.yml
+++ b/.github/workflows/test-petab-test-suite.yml
@@ -53,11 +53,17 @@ jobs:
     # retrieve test models
     - name: Download and run petab test suite
       run: |
-        git clone --depth 1 https://github.com/petab-dev/petab_test_suite \
+        git clone --depth 1 https://github.com/FFroehlich/petab_test_suite \
           && source ./build/venv/bin/activate \
-          && cd petab_test_suite; pip3 install -e .; cd .. \
+          && cd petab_test_suite; git checkout pysb; pip3 install -e .; cd .. \
           && AMICI_PARALLEL_COMPILE=2 pytest -v \
             --cov-report=xml --cov-append --cov=amici tests/petab_test_suite/
+#      run: |
+#          git clone --depth 1 https://github.com/petab-dev/petab_test_suite \
+#          && source ./build/venv/bin/activate \
+#          && cd petab_test_suite; pip3 install -e .; cd .. \
+#          && AMICI_PARALLEL_COMPILE=2 pytest -v \
+#            --cov-report=xml --cov-append --cov=amici tests/petab_test_suite/
 
     - name: Codecov
       uses: codecov/codecov-action@v1

--- a/.github/workflows/test-petab-test-suite.yml
+++ b/.github/workflows/test-petab-test-suite.yml
@@ -41,10 +41,9 @@ jobs:
       run: |
         scripts/buildBNGL.sh
     - run: |
-        echo "::set-env name=AMICI_DIR::$(pwd)"
         echo "::add-path::${HOME}/.local/bin/"
         echo "::add-path::${GITHUB_WORKSPACE}/tests/performance/"
-        echo "::set-env name=BNGPATH::${AMICI_DIR}/ThirdParty/BioNetGen-2.3.2"
+        echo "::set-env name=BNGPATH::${GITHUB_WORKSPACE}/ThirdParty/BioNetGen-2.3.2"
     # install AMICI
     - name: Install python package
       run: |

--- a/.github/workflows/test-petab-test-suite.yml
+++ b/.github/workflows/test-petab-test-suite.yml
@@ -37,6 +37,9 @@ jobs:
         pip3 install --upgrade --user wheel \
           && pip3 install --upgrade --user setuptools
     - run: pip3 install pytest shyaml pytest-cov pysb petab
+    - name: Build BNGL
+      run: |
+        scripts/buildBNGL.sh
     - run: |
         echo ::add-path::${HOME}/.local/bin/
         echo ::add-path::${GITHUB_WORKSPACE}/tests/performance/

--- a/python/amici/__init__.py
+++ b/python/amici/__init__.py
@@ -281,29 +281,27 @@ def import_model_module(module_name: str,
     """
     Import Python module of an AMICI model
 
-    :param module_name: Name of the python package for the model
-    :param module_path: Absolute path of the package directory
+    :param module_name: Name of the python package of the model
+    :param module_path: Absolute or relative path of the package directory
     :return: The model module
     """
 
     # ensure we will find the newly created module
     importlib.invalidate_caches()
 
-    # TODO: cleanup, add test, reload? with pathcheck?
+    # module already loaded?
+    if module_name in sys.modules:
+        # if a module with that name is already in sys.modules, we remove it,
+        # along with all other modules from that package. otherwise, there
+        # will be trouble if two different models with the same name are to
+        # be imported.
+        del sys.modules[module_name]
+        # collect first, don't delete while iterating
+        to_unload = {loaded_module_name for loaded_module_name in
+                     sys.modules.keys() if
+                     loaded_module_name.startswith(f"{module_name}.")}
+        for m in to_unload:
+            del sys.modules[m]
 
     with add_path(module_path):
-        # module already loaded?
-        # if module_name in sys.modules:
-        #     # reload, because may just have been created
-        #     importlib.reload(sys.modules[module_name])
-        #     return sys.modules[module_name]
-        if module_name in sys.modules:
-            del sys.modules[module_name]
-            to_unload = {loaded_module_name for loaded_module_name in
-                         sys.modules.keys() if
-                         loaded_module_name.startswith(f"{module_name}.")}
-            for m in to_unload:
-                del sys.modules[m]
-
-
         return importlib.import_module(module_name)

--- a/python/amici/__init__.py
+++ b/python/amici/__init__.py
@@ -281,19 +281,29 @@ def import_model_module(module_name: str,
     """
     Import Python module of an AMICI model
 
-    :param module_name: Name of the python module for the model
-    :param module_path: Absolute path of the module
+    :param module_name: Name of the python package for the model
+    :param module_path: Absolute path of the package directory
     :return: The model module
     """
 
     # ensure we will find the newly created module
     importlib.invalidate_caches()
 
+    # TODO: cleanup, add test, reload? with pathcheck?
+
     with add_path(module_path):
         # module already loaded?
+        # if module_name in sys.modules:
+        #     # reload, because may just have been created
+        #     importlib.reload(sys.modules[module_name])
+        #     return sys.modules[module_name]
         if module_name in sys.modules:
-            # reload, because may just have been created
-            importlib.reload(sys.modules[module_name])
-            return sys.modules[module_name]
+            del sys.modules[module_name]
+            to_unload = {loaded_module_name for loaded_module_name in
+                         sys.modules.keys() if
+                         loaded_module_name.startswith(f"{module_name}.")}
+            for m in to_unload:
+                del sys.modules[m]
+
 
         return importlib.import_module(module_name)

--- a/python/amici/__init__.py
+++ b/python/amici/__init__.py
@@ -289,6 +289,11 @@ def import_model_module(module_name: str,
     # ensure we will find the newly created module
     importlib.invalidate_caches()
 
+    if not os.path.isdir(module_path):
+        raise ValueError(f"module_path '{module_path}' is not a directory.")
+
+    module_path = os.path.abspath(module_path)
+
     # module already loaded?
     if module_name in sys.modules:
         # if a module with that name is already in sys.modules, we remove it,

--- a/python/amici/petab_import.py
+++ b/python/amici/petab_import.py
@@ -295,7 +295,7 @@ def import_petab_problem(
                 model_output_dir=model_output_dir,
                 **kwargs)
         else:
-            import_model(
+            import_model_sbml(
                 sbml_model=petab_problem.sbml_model,
                 condition_table=petab_problem.condition_df,
                 observable_table=petab_problem.observable_df,

--- a/python/amici/petab_import.py
+++ b/python/amici/petab_import.py
@@ -497,8 +497,7 @@ def import_petab_problem(
         # compile the model
         if isinstance(petab_problem, PysbPetabProblem):
             import_model_pysb(
-                petab_problem.pysb_model_module,
-                observable_table=petab_problem.observable_df,
+                petab_problem,
                 model_output_dir=model_output_dir,
                 **kwargs)
         else:
@@ -761,8 +760,7 @@ import_model_sbml = import_model
 
 @log_execution_time('Importing PEtab model', logger)
 def import_model_pysb(
-        pysb_model_module: 'pysb.Model',
-        observable_table: Optional[Union[str, pd.DataFrame]] = None,
+        petab_problem: PysbPetabProblem,
         model_output_dir: Optional[str] = None,
         verbose: Optional[Union[bool, int]] = True,
         **kwargs
@@ -770,19 +768,8 @@ def import_model_pysb(
     """
     Create AMICI model from PEtab problem
 
-    :param sbml_model:
-        PEtab SBML model or SBML file name.
-
-    :param condition_table:
-        PEtab condition table. If provided, parameters from there will be
-        turned into AMICI constant parameters (i.e. parameters w.r.t. which
-        no sensitivities will be computed).
-
-    :param observable_table:
-        PEtab observable table.
-
-    :param measurement_table:
-        PEtab measurement table.
+    :param petab_problem:
+        PySB PEtab problem
 
     :param model_output_dir:
         Directory to write the model code to. Will be created if doesn't
@@ -800,8 +787,11 @@ def import_model_pysb(
 
     logger.info(f"Importing model ...")
 
-    # TODO constant_parameters
-    constant_parameters = None
+    observable_table = petab_problem.observable_df
+    pysb_model_module = petab_problem.pysb_model_module
+
+    constant_parameters = get_fixed_parameters(petab_problem.sbml_model,
+                                               petab_problem.condition_df)
 
     if observable_table is None:
         observables = None

--- a/python/amici/petab_import.py
+++ b/python/amici/petab_import.py
@@ -1,7 +1,7 @@
 """
 PEtab Import
 ------------
-Import a model in the :mod:`petab` (https://github.com/ICB-DCM/PEtab/) format
+Import a model in the :mod:`petab` (https://github.com/PEtab-dev/PEtab) format
 into AMICI.
 """
 
@@ -11,19 +11,18 @@ import logging
 import math
 import os
 import shutil
-import sys
 import tempfile
 from _collections import OrderedDict
 from itertools import chain
-from typing import List, Dict, Union, Optional, Tuple, Iterable
+from typing import List, Dict, Union, Optional, Tuple
 
 import amici
 import libsbml
 import pandas as pd
 import petab
 import sympy as sp
-
 from amici.logging import get_logger, log_execution_time, set_log_level
+from amici.petab_import_pysb import PysbPetabProblem, import_model_pysb
 from petab.C import *
 
 logger = get_logger(__name__, logging.WARNING)
@@ -31,210 +30,6 @@ logger = get_logger(__name__, logging.WARNING)
 # ID of model parameter that is to be added to SBML model to indicate
 #  preequilibration
 PREEQ_INDICATOR_ID = 'preequilibration_indicator'
-
-
-class PysbPetabProblem(petab.Problem):
-    def __init__(self, pysb_model_module: 'pysb.Model' = None,
-                 *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.pysb_model_module = pysb_model_module
-        import pysb
-
-        # add any required output parameters
-        # sp.Symbol.__str__(comp)
-        locals = {sp.Symbol.__str__(comp): comp for comp in
-                  pysb_model_module.components if
-                  isinstance(comp, sp.Symbol)}
-        for formula in [*self.observable_df[petab.OBSERVABLE_FORMULA],
-                       *self.observable_df[petab.NOISE_FORMULA]]:
-            sym = sp.sympify(formula, locals=locals)
-            for s in sym.free_symbols:
-                if not isinstance(s, pysb.Component):
-                    p = pysb.Parameter(str(s), 1.0)
-                    locals[sp.Symbol.__str__(p)] = p
-
-
-        # add observables and sigmas to pysb model
-        for (observable_id, observable_formula, noise_formula) \
-                in zip(self.observable_df.index,
-                       self.observable_df[petab.OBSERVABLE_FORMULA],
-                       self.observable_df[petab.NOISE_FORMULA]):
-            if petab.OBSERVABLE_TRANSFORMATION in self.observable_df:
-                trafo = self.observable_df.loc[observable_id, petab.OBSERVABLE_TRANSFORMATION]
-                if trafo and trafo != petab.LIN:
-                    raise NotImplementedError("Observable transformation currently unsupported for PySB models")
-            obs_symbol = sp.sympify(
-                    observable_formula,
-                    locals=locals
-                )
-            ex = pysb.Expression(observable_id, obs_symbol)
-            locals[observable_id] = ex
-
-            sigma_id = f"{observable_id}_sigma"  # TODO naming?
-            sigma_symbol = sp.sympify(
-                    noise_formula,
-                    locals=locals
-                )
-            ex = pysb.Expression(sigma_id, sigma_symbol)
-            locals[sigma_id] = ex
-
-        if self.pysb_model_module is not None:
-            self.sbml_document, self.sbml_model = create_dummy_sbml(
-                self.pysb_model_module,
-                observable_ids=self.observable_df.index.values
-                if self.observable_df is not None else None
-            )
-
-    @staticmethod
-    def from_files(sbml_file: str = None,
-                   condition_file: str = None,
-                   measurement_file: Union[str, Iterable[str]] = None,
-                   parameter_file: Union[str, List[str]] = None,
-                   visualization_files: Union[str, Iterable[str]] = None,
-                   observable_files: Union[str, Iterable[str]] = None,
-                   pysb_model_file: str = None,
-                   ) -> 'PysbPetabProblem':
-        """
-        Factory method to load model and tables from files.
-
-        Arguments:
-            sbml_file: PEtab SBML model
-            condition_file: PEtab condition table
-            measurement_file: PEtab measurement table
-            parameter_file: PEtab parameter table
-            visualization_files: PEtab visualization tables
-            observable_files: PEtab observables tables
-            pysb_model_file: PySB model file
-        """
-
-        sbml_model = sbml_document = sbml_reader = None
-        condition_df = measurement_df = parameter_df = visualization_df = None
-        observable_df = None
-
-        if condition_file:
-            condition_df = petab.conditions.get_condition_df(condition_file)
-
-        if measurement_file:
-            # If there are multiple tables, we will merge them
-            measurement_df = petab.core.concat_tables(
-                measurement_file, petab.measurements.get_measurement_df)
-
-        if parameter_file:
-            parameter_df = petab.parameters.get_parameter_df(parameter_file)
-
-        if sbml_file:
-            sbml_reader = libsbml.SBMLReader()
-            sbml_document = sbml_reader.readSBML(sbml_file)
-            sbml_model = sbml_document.getModel()
-
-        if visualization_files:
-            # If there are multiple tables, we will merge them
-            visualization_df = petab.core.concat_tables(
-                visualization_files, petab.core.get_visualization_df)
-
-        if observable_files:
-            # If there are multiple tables, we will merge them
-            observable_df = petab.core.concat_tables(
-                observable_files, petab.observables.get_observable_df)
-        from amici.pysb_import import pysb_model_from_path
-        return PysbPetabProblem(
-            pysb_model_module=pysb_model_from_path(
-                pysb_model_file=pysb_model_file),
-            condition_df=condition_df,
-            measurement_df=measurement_df,
-            parameter_df=parameter_df,
-            observable_df=observable_df,
-            sbml_model=sbml_model,
-            sbml_document=sbml_document,
-            sbml_reader=sbml_reader,
-            visualization_df=visualization_df)
-
-    @staticmethod
-    def from_yaml(yaml_config: Union[Dict, str]) -> 'PysbPetabProblem':
-        """
-        Factory method to load model and tables as specified by YAML file.
-
-        Arguments:
-            yaml_config: PEtab configuration as dictionary or YAML file name
-        """
-        from petab.yaml import (load_yaml, is_composite_problem,
-                                assert_single_condition_and_sbml_file)
-        if isinstance(yaml_config, str):
-            path_prefix = os.path.dirname(yaml_config)
-            yaml_config = load_yaml(yaml_config)
-        else:
-            path_prefix = ""
-
-        if is_composite_problem(yaml_config):
-            raise ValueError('petab.Problem.from_yaml() can only be used for '
-                             'yaml files comprising a single model. '
-                             'Consider using '
-                             'petab.CompositeProblem.from_yaml() instead.')
-
-        if yaml_config[FORMAT_VERSION] != petab.__format_version__:
-            raise ValueError("Provided PEtab files are of unsupported version"
-                             f"{yaml_config[FORMAT_VERSION]}. Expected "
-                             f"{petab.__format_version__}.")
-
-        problem0 = yaml_config['problems'][0]
-
-        assert_single_condition_and_sbml_file(problem0)
-
-        if isinstance(yaml_config[PARAMETER_FILE], list):
-            parameter_file = [
-                os.path.join(path_prefix, f)
-                for f in yaml_config[PARAMETER_FILE]
-            ]
-        else:
-            parameter_file = os.path.join(
-                path_prefix, yaml_config[PARAMETER_FILE])
-
-        return PysbPetabProblem.from_files(
-            pysb_model_file=os.path.join(
-                path_prefix, problem0[SBML_FILES][0]),
-            measurement_file=[os.path.join(path_prefix, f)
-                              for f in problem0[MEASUREMENT_FILES]],
-            condition_file=os.path.join(
-                path_prefix, problem0[CONDITION_FILES][0]),
-            parameter_file=parameter_file,
-            visualization_files=[
-                os.path.join(path_prefix, f)
-                for f in problem0.get(VISUALIZATION_FILES, [])],
-            observable_files=[
-                os.path.join(path_prefix, f)
-                for f in problem0.get(OBSERVABLE_FILES, [])]
-        )
-
-
-def create_dummy_sbml(pysb_model: 'pysb.Model', observable_ids=None
-                      ) -> Tuple['libsbml.Model', 'libsbml.SBMLDocument']:
-    """Create SBML dummy model for to use pysb Models with PEtab.
-
-    Model must at least contain petab problem parameter and noise parameters
-    for observables.
-    """
-
-    import libsbml
-
-    document = libsbml.SBMLDocument(3, 1)
-    dummy_sbml_model = document.createModel()
-    dummy_sbml_model.setTimeUnits("second")
-    dummy_sbml_model.setExtentUnits("mole")
-    dummy_sbml_model.setSubstanceUnits('mole')
-
-    for species in pysb_model.parameters:
-        p = dummy_sbml_model.createParameter()
-        p.setId(species.name)
-        p.setConstant(True)
-        p.setValue(0.0)
-
-    for observable_id in observable_ids:
-        p = dummy_sbml_model.createParameter()
-        p.setId(f"noiseParameter1_{observable_id}")
-        p.setConstant(True)
-        p.setValue(0.0)
-
-    return document, dummy_sbml_model
 
 
 def get_fixed_parameters(
@@ -469,7 +264,7 @@ def import_petab_problem(
 
     if isinstance(petab_problem, PysbPetabProblem):
         if model_name is None:
-            model_name = petab_problem.pysb_model_module.name
+            model_name = petab_problem.pysb_model.name
         else:
             raise ValueError(
                 "Argument model_name currently not allowed for pysb models")
@@ -566,7 +361,7 @@ def _can_import_model(model_name: str) -> bool:
 
 
 @log_execution_time('Importing PEtab model', logger)
-def import_model(sbml_model: Union[str, 'libsbml.Model'],
+def import_model_sbml(sbml_model: Union[str, 'libsbml.Model'],
                  condition_table: Optional[Union[str, pd.DataFrame]] = None,
                  observable_table: Optional[Union[str, pd.DataFrame]] = None,
                  measurement_table: Optional[Union[str, pd.DataFrame]] = None,
@@ -754,79 +549,8 @@ def import_model(sbml_model: Union[str, 'libsbml.Model'],
         **kwargs)
 
 
-import_model_sbml = import_model
-
-
-@log_execution_time('Importing PEtab model', logger)
-def import_model_pysb(
-        petab_problem: PysbPetabProblem,
-        model_output_dir: Optional[str] = None,
-        verbose: Optional[Union[bool, int]] = True,
-        **kwargs
-) -> None:
-    """
-    Create AMICI model from PEtab problem
-
-    :param petab_problem:
-        PySB PEtab problem
-
-    :param model_output_dir:
-        Directory to write the model code to. Will be created if doesn't
-        exist. Defaults to current directory.
-
-    :param verbose:
-        Print/log extra information.
-
-    :param kwargs:
-        Additional keyword arguments to be passed to
-        :meth:`amici.sbml_import.SbmlImporter.sbml2amici`.
-    """
-
-    set_log_level(logger, verbose)
-
-    logger.info(f"Importing model ...")
-
-    observable_table = petab_problem.observable_df
-    pysb_model_module = petab_problem.pysb_model_module
-
-    # For pysb, we only allow parameters in the condition table
-    # those must be pysb model parameters (either natively, or output
-    # parameters from measurement or condition table that have been added in
-    # PysbPetabProblem
-    model_parameters = [p.name for p in pysb_model_module.parameters]
-    for x in petab_problem.condition_df.columns:
-        if x == petab.CONDITION_NAME: continue
-        if x not in model_parameters:
-            raise NotImplementedError(
-                "For PySB PEtab import, only model parameters, but no states "
-                "or compartments are allowed in the condition table."
-                f"Offending column: {x}"
-            )
-
-
-    constant_parameters = get_fixed_parameters(petab_problem.sbml_model,
-                                               petab_problem.condition_df)
-
-    if observable_table is None:
-        observables = None
-        sigmas = None
-    else:
-        observables = [expr.name for expr in pysb_model_module.expressions
-                       if expr.name in observable_table.index]
-
-        def get_expr(x):
-            for expr in pysb_model_module.expressions:
-                if expr.name == x:
-                    return expr
-        sigmas = {obs_id: get_expr(f"{obs_id}_sigma") for obs_id in observables}
-
-    from amici.pysb_import import pysb2amici
-    pysb2amici(pysb_model_module, model_output_dir, verbose=True,
-               observables=observables,
-               sigmas=sigmas,
-               constant_parameters=constant_parameters,
-               # compute_conservation_laws=False,
-               **kwargs)
+# for backwards compatibility
+import_model = import_model_sbml
 
 
 def get_observation_model(observable_df: pd.DataFrame

--- a/python/amici/petab_import.py
+++ b/python/amici/petab_import.py
@@ -790,6 +790,21 @@ def import_model_pysb(
     observable_table = petab_problem.observable_df
     pysb_model_module = petab_problem.pysb_model_module
 
+    # For pysb, we only allow parameters in the condition table
+    # those must be pysb model parameters (either natively, or output
+    # parameters from measurement or condition table that have been added in
+    # PysbPetabProblem
+    model_parameters = [p.name for p in pysb_model_module.parameters]
+    for x in petab_problem.condition_df.columns:
+        if x == petab.CONDITION_NAME: continue
+        if x not in model_parameters:
+            raise NotImplementedError(
+                "For PySB PEtab import, only model parameters, but no states "
+                "or compartments are allowed in the condition table."
+                f"Offending column: {x}"
+            )
+
+
     constant_parameters = get_fixed_parameters(petab_problem.sbml_model,
                                                petab_problem.condition_df)
 

--- a/python/amici/petab_import.py
+++ b/python/amici/petab_import.py
@@ -25,7 +25,6 @@ import sympy as sp
 
 from amici.logging import get_logger, log_execution_time, set_log_level
 from petab.C import *
-from amici.pysb_import import pysb2amici
 
 logger = get_logger(__name__, logging.WARNING)
 
@@ -821,6 +820,7 @@ def import_model_pysb(
                     return expr
         sigmas = {obs_id: get_expr(f"{obs_id}_sigma") for obs_id in observables}
 
+    from amici.pysb_import import pysb2amici
     pysb2amici(pysb_model_module, model_output_dir, verbose=True,
                observables=observables,
                sigmas=sigmas,

--- a/python/amici/petab_import_pysb.py
+++ b/python/amici/petab_import_pysb.py
@@ -1,0 +1,309 @@
+"""
+PySB-PEtab Import
+------------
+Import a model in the PySB-adapted :mod:`petab`
+(https://github.com/PEtab-dev/PEtab) format into AMICI.
+"""
+
+import logging
+import os
+from typing import List, Dict, Union, Optional, Tuple, Iterable
+
+import libsbml
+import petab
+import sympy as sp
+from petab.C import *
+
+from .logging import get_logger, log_execution_time, set_log_level
+from . import petab_import
+
+logger = get_logger(__name__, logging.WARNING)
+
+
+class PysbPetabProblem(petab.Problem):
+    """Representation of a PySB-model-based PEtab problem
+
+    This class extends :class:`petab.Problem` with a PySB model.
+    The model is augmented with the observation model based on the PEtab
+    observable table.
+    For now, a dummy SBML model is created which allows used the existing
+    SBML-PEtab API.
+
+    :ivar pysb_model:
+        PySB model instance from of this PEtab problem.
+
+    """
+
+    def __init__(self, pysb_model: 'pysb.Model' = None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.pysb_model: 'pysb.Model' = pysb_model
+        import pysb
+
+        # add any required output parameters
+        # sp.Symbol.__str__(comp)
+        locals = {sp.Symbol.__str__(comp): comp for comp in
+                  pysb_model.components if
+                  isinstance(comp, sp.Symbol)}
+        for formula in [*self.observable_df[petab.OBSERVABLE_FORMULA],
+                       *self.observable_df[petab.NOISE_FORMULA]]:
+            sym = sp.sympify(formula, locals=locals)
+            for s in sym.free_symbols:
+                if not isinstance(s, pysb.Component):
+                    p = pysb.Parameter(str(s), 1.0)
+                    locals[sp.Symbol.__str__(p)] = p
+
+
+        # add observables and sigmas to pysb model
+        for (observable_id, observable_formula, noise_formula) \
+                in zip(self.observable_df.index,
+                       self.observable_df[petab.OBSERVABLE_FORMULA],
+                       self.observable_df[petab.NOISE_FORMULA]):
+            if petab.OBSERVABLE_TRANSFORMATION in self.observable_df:
+                trafo = self.observable_df.loc[observable_id, petab.OBSERVABLE_TRANSFORMATION]
+                if trafo and trafo != petab.LIN:
+                    raise NotImplementedError("Observable transformation currently unsupported for PySB models")
+            obs_symbol = sp.sympify(
+                    observable_formula,
+                    locals=locals
+                )
+            ex = pysb.Expression(observable_id, obs_symbol)
+            locals[observable_id] = ex
+
+            sigma_id = f"{observable_id}_sigma"  # TODO naming?
+            sigma_symbol = sp.sympify(
+                    noise_formula,
+                    locals=locals
+                )
+            ex = pysb.Expression(sigma_id, sigma_symbol)
+            locals[sigma_id] = ex
+
+        if self.pysb_model is not None:
+            self.sbml_document, self.sbml_model = create_dummy_sbml(
+                self.pysb_model,
+                observable_ids=self.observable_df.index.values
+                if self.observable_df is not None else None
+            )
+
+    @staticmethod
+    def from_files(sbml_file: str = None,
+                   condition_file: str = None,
+                   measurement_file: Union[str, Iterable[str]] = None,
+                   parameter_file: Union[str, List[str]] = None,
+                   visualization_files: Union[str, Iterable[str]] = None,
+                   observable_files: Union[str, Iterable[str]] = None,
+                   pysb_model_file: str = None,
+                   ) -> 'PysbPetabProblem':
+        """
+        Factory method to load model and tables from files.
+
+        Arguments:
+            sbml_file: PEtab SBML model
+            condition_file: PEtab condition table
+            measurement_file: PEtab measurement table
+            parameter_file: PEtab parameter table
+            visualization_files: PEtab visualization tables
+            observable_files: PEtab observables tables
+            pysb_model_file: PySB model file
+        """
+
+        sbml_model = sbml_document = sbml_reader = None
+        condition_df = measurement_df = parameter_df = visualization_df = None
+        observable_df = None
+
+        if condition_file:
+            condition_df = petab.conditions.get_condition_df(condition_file)
+
+        if measurement_file:
+            # If there are multiple tables, we will merge them
+            measurement_df = petab.core.concat_tables(
+                measurement_file, petab.measurements.get_measurement_df)
+
+        if parameter_file:
+            parameter_df = petab.parameters.get_parameter_df(parameter_file)
+
+        if sbml_file:
+            sbml_reader = libsbml.SBMLReader()
+            sbml_document = sbml_reader.readSBML(sbml_file)
+            sbml_model = sbml_document.getModel()
+
+        if visualization_files:
+            # If there are multiple tables, we will merge them
+            visualization_df = petab.core.concat_tables(
+                visualization_files, petab.core.get_visualization_df)
+
+        if observable_files:
+            # If there are multiple tables, we will merge them
+            observable_df = petab.core.concat_tables(
+                observable_files, petab.observables.get_observable_df)
+        from amici.pysb_import import pysb_model_from_path
+        return PysbPetabProblem(
+            pysb_model=pysb_model_from_path(
+                pysb_model_file=pysb_model_file),
+            condition_df=condition_df,
+            measurement_df=measurement_df,
+            parameter_df=parameter_df,
+            observable_df=observable_df,
+            sbml_model=sbml_model,
+            sbml_document=sbml_document,
+            sbml_reader=sbml_reader,
+            visualization_df=visualization_df)
+
+    @staticmethod
+    def from_yaml(yaml_config: Union[Dict, str]) -> 'PysbPetabProblem':
+        """
+        Factory method to load model and tables as specified by YAML file.
+
+        Arguments:
+            yaml_config: PEtab configuration as dictionary or YAML file name
+        """
+        from petab.yaml import (load_yaml, is_composite_problem,
+                                assert_single_condition_and_sbml_file)
+        if isinstance(yaml_config, str):
+            path_prefix = os.path.dirname(yaml_config)
+            yaml_config = load_yaml(yaml_config)
+        else:
+            path_prefix = ""
+
+        if is_composite_problem(yaml_config):
+            raise ValueError('petab.Problem.from_yaml() can only be used for '
+                             'yaml files comprising a single model. '
+                             'Consider using '
+                             'petab.CompositeProblem.from_yaml() instead.')
+
+        if yaml_config[FORMAT_VERSION] != petab.__format_version__:
+            raise ValueError("Provided PEtab files are of unsupported version"
+                             f"{yaml_config[FORMAT_VERSION]}. Expected "
+                             f"{petab.__format_version__}.")
+
+        problem0 = yaml_config['problems'][0]
+
+        assert_single_condition_and_sbml_file(problem0)
+
+        if isinstance(yaml_config[PARAMETER_FILE], list):
+            parameter_file = [
+                os.path.join(path_prefix, f)
+                for f in yaml_config[PARAMETER_FILE]
+            ]
+        else:
+            parameter_file = os.path.join(
+                path_prefix, yaml_config[PARAMETER_FILE])
+
+        return PysbPetabProblem.from_files(
+            pysb_model_file=os.path.join(
+                path_prefix, problem0[SBML_FILES][0]),
+            measurement_file=[os.path.join(path_prefix, f)
+                              for f in problem0[MEASUREMENT_FILES]],
+            condition_file=os.path.join(
+                path_prefix, problem0[CONDITION_FILES][0]),
+            parameter_file=parameter_file,
+            visualization_files=[
+                os.path.join(path_prefix, f)
+                for f in problem0.get(VISUALIZATION_FILES, [])],
+            observable_files=[
+                os.path.join(path_prefix, f)
+                for f in problem0.get(OBSERVABLE_FILES, [])]
+        )
+
+
+def create_dummy_sbml(pysb_model: 'pysb.Model', observable_ids=None
+                      ) -> Tuple['libsbml.Model', 'libsbml.SBMLDocument']:
+    """Create SBML dummy model for to use pysb Models with PEtab.
+
+    Model must at least contain petab problem parameter and noise parameters
+    for observables.
+    """
+
+    import libsbml
+
+    document = libsbml.SBMLDocument(3, 1)
+    dummy_sbml_model = document.createModel()
+    dummy_sbml_model.setTimeUnits("second")
+    dummy_sbml_model.setExtentUnits("mole")
+    dummy_sbml_model.setSubstanceUnits('mole')
+
+    for species in pysb_model.parameters:
+        p = dummy_sbml_model.createParameter()
+        p.setId(species.name)
+        p.setConstant(True)
+        p.setValue(0.0)
+
+    for observable_id in observable_ids:
+        p = dummy_sbml_model.createParameter()
+        p.setId(f"noiseParameter1_{observable_id}")
+        p.setConstant(True)
+        p.setValue(0.0)
+
+    return document, dummy_sbml_model
+
+
+
+
+@log_execution_time('Importing PEtab model', logger)
+def import_model_pysb(
+        petab_problem: PysbPetabProblem,
+        model_output_dir: Optional[str] = None,
+        verbose: Optional[Union[bool, int]] = True,
+        **kwargs
+) -> None:
+    """
+    Create AMICI model from PEtab problem
+
+    :param petab_problem:
+        PySB PEtab problem
+
+    :param model_output_dir:
+        Directory to write the model code to. Will be created if doesn't
+        exist. Defaults to current directory.
+
+    :param verbose:
+        Print/log extra information.
+
+    :param kwargs:
+        Additional keyword arguments to be passed to
+        :meth:`amici.sbml_import.SbmlImporter.sbml2amici`.
+    """
+
+    set_log_level(logger, verbose)
+
+    logger.info(f"Importing model ...")
+
+    observable_table = petab_problem.observable_df
+    pysb_model_module = petab_problem.pysb_model
+
+    # For pysb, we only allow parameters in the condition table
+    # those must be pysb model parameters (either natively, or output
+    # parameters from measurement or condition table that have been added in
+    # PysbPetabProblem
+    model_parameters = [p.name for p in pysb_model_module.parameters]
+    for x in petab_problem.condition_df.columns:
+        if x == petab.CONDITION_NAME: continue
+        if x not in model_parameters:
+            raise NotImplementedError(
+                "For PySB PEtab import, only model parameters, but no states "
+                "or compartments are allowed in the condition table."
+                f"Offending column: {x}"
+            )
+
+    constant_parameters = petab_import.get_fixed_parameters(
+        petab_problem.sbml_model, petab_problem.condition_df)
+
+    if observable_table is None:
+        observables = None
+        sigmas = None
+    else:
+        observables = [expr.name for expr in pysb_model_module.expressions
+                       if expr.name in observable_table.index]
+
+        def get_expr(x):
+            for expr in pysb_model_module.expressions:
+                if expr.name == x:
+                    return expr
+        sigmas = {obs_id: get_expr(f"{obs_id}_sigma") for obs_id in observables}
+
+    from amici.pysb_import import pysb2amici
+    pysb2amici(pysb_model_module, model_output_dir, verbose=True,
+               observables=observables,
+               sigmas=sigmas,
+               constant_parameters=constant_parameters,
+               # compute_conservation_laws=False,
+               **kwargs)

--- a/python/amici/petab_import_pysb.py
+++ b/python/amici/petab_import_pysb.py
@@ -310,14 +310,7 @@ def import_model_pysb(
         observables = [expr.name for expr in pysb_model.expressions
                        if expr.name in observable_table.index]
 
-        def get_expr(x):
-            """Get pysb model expression by name"""
-            for expr in pysb_model.expressions:
-                if expr.name == x:
-                    return expr
-
-        sigmas = {obs_id: get_expr(f"{obs_id}_sigma") for obs_id in
-                  observables}
+        sigmas = {obs_id: f"{obs_id}_sigma" for obs_id in observables}
 
     from amici.pysb_import import pysb2amici
     pysb2amici(pysb_model, model_output_dir, verbose=True,

--- a/python/amici/petab_import_pysb.py
+++ b/python/amici/petab_import_pysb.py
@@ -100,8 +100,7 @@ class PysbPetabProblem(petab.Problem):
             locals[sigma_id] = sigma_expr
 
     @staticmethod
-    def from_files(sbml_file: str = None,
-                   condition_file: str = None,
+    def from_files(condition_file: str = None,
                    measurement_file: Union[str, Iterable[str]] = None,
                    parameter_file: Union[str, List[str]] = None,
                    visualization_files: Union[str, Iterable[str]] = None,
@@ -112,7 +111,6 @@ class PysbPetabProblem(petab.Problem):
         Factory method to load model and tables from files.
 
         Arguments:
-            sbml_file: PEtab SBML model
             condition_file: PEtab condition table
             measurement_file: PEtab measurement table
             parameter_file: PEtab parameter table
@@ -121,7 +119,6 @@ class PysbPetabProblem(petab.Problem):
             pysb_model_file: PySB model file
         """
 
-        sbml_model = sbml_document = sbml_reader = None
         condition_df = measurement_df = parameter_df = visualization_df = None
         observable_df = None
 
@@ -135,11 +132,6 @@ class PysbPetabProblem(petab.Problem):
 
         if parameter_file:
             parameter_df = petab.parameters.get_parameter_df(parameter_file)
-
-        if sbml_file:
-            sbml_reader = libsbml.SBMLReader()
-            sbml_document = sbml_reader.readSBML(sbml_file)
-            sbml_model = sbml_document.getModel()
 
         if visualization_files:
             # If there are multiple tables, we will merge them
@@ -158,9 +150,6 @@ class PysbPetabProblem(petab.Problem):
             measurement_df=measurement_df,
             parameter_df=parameter_df,
             observable_df=observable_df,
-            sbml_model=sbml_model,
-            sbml_document=sbml_document,
-            sbml_reader=sbml_reader,
             visualization_df=visualization_df)
 
     @staticmethod

--- a/python/amici/petab_import_pysb.py
+++ b/python/amici/petab_import_pysb.py
@@ -63,16 +63,16 @@ class PysbPetabProblem(petab.Problem):
         import pysb
 
         # add any required output parameters
-        locals = {sp.Symbol.__str__(comp): comp for comp in
-                  self.pysb_model.components if
-                  isinstance(comp, sp.Symbol)}
+        local_syms = {sp.Symbol.__str__(comp): comp for comp in
+                      self.pysb_model.components if
+                      isinstance(comp, sp.Symbol)}
         for formula in [*self.observable_df[petab.OBSERVABLE_FORMULA],
                         *self.observable_df[petab.NOISE_FORMULA]]:
-            sym = sp.sympify(formula, locals=locals)
+            sym = sp.sympify(formula, locals=local_syms)
             for s in sym.free_symbols:
                 if not isinstance(s, pysb.Component):
                     p = pysb.Parameter(str(s), 1.0)
-                    locals[sp.Symbol.__str__(p)] = p
+                    local_syms[sp.Symbol.__str__(p)] = p
 
         # add observables and sigmas to pysb model
         for (observable_id, observable_formula, noise_formula) \
@@ -87,17 +87,17 @@ class PysbPetabProblem(petab.Problem):
                     raise NotImplementedError(
                         "Observable transformation currently unsupported "
                         "for PySB models")
-            obs_symbol = sp.sympify(observable_formula, locals=locals)
+            obs_symbol = sp.sympify(observable_formula, locals=local_syms)
             obs_expr = pysb.Expression(observable_id, obs_symbol)
-            locals[observable_id] = obs_expr
+            local_syms[observable_id] = obs_expr
 
             sigma_id = f"{observable_id}_sigma"
             sigma_symbol = sp.sympify(
                 noise_formula,
-                locals=locals
+                locals=local_syms
             )
             sigma_expr = pysb.Expression(sigma_id, sigma_symbol)
-            locals[sigma_id] = sigma_expr
+            local_syms[sigma_id] = sigma_expr
 
     @staticmethod
     def from_files(condition_file: str = None,

--- a/python/amici/petab_import_pysb.py
+++ b/python/amici/petab_import_pysb.py
@@ -12,7 +12,10 @@ from typing import List, Dict, Union, Optional, Tuple, Iterable
 import libsbml
 import petab
 import sympy as sp
-from petab.C import *
+from petab.C import (CONDITION_NAME, OBSERVABLE_TRANSFORMATION, LIN,
+                     OBSERVABLE_FORMULA, NOISE_FORMULA, FORMAT_VERSION,
+                     PARAMETER_FILE, SBML_FILES, CONDITION_FILES,
+                     MEASUREMENT_FILES, VISUALIZATION_FILES, OBSERVABLE_FILES)
 
 from .logging import get_logger, log_execution_time, set_log_level
 from . import petab_import
@@ -66,8 +69,8 @@ class PysbPetabProblem(petab.Problem):
         local_syms = {sp.Symbol.__str__(comp): comp for comp in
                       self.pysb_model.components if
                       isinstance(comp, sp.Symbol)}
-        for formula in [*self.observable_df[petab.OBSERVABLE_FORMULA],
-                        *self.observable_df[petab.NOISE_FORMULA]]:
+        for formula in [*self.observable_df[OBSERVABLE_FORMULA],
+                        *self.observable_df[NOISE_FORMULA]]:
             sym = sp.sympify(formula, locals=local_syms)
             for s in sym.free_symbols:
                 if not isinstance(s, pysb.Component):
@@ -77,13 +80,13 @@ class PysbPetabProblem(petab.Problem):
         # add observables and sigmas to pysb model
         for (observable_id, observable_formula, noise_formula) \
                 in zip(self.observable_df.index,
-                       self.observable_df[petab.OBSERVABLE_FORMULA],
-                       self.observable_df[petab.NOISE_FORMULA]):
+                       self.observable_df[OBSERVABLE_FORMULA],
+                       self.observable_df[NOISE_FORMULA]):
             # No observableTransformation so far
-            if petab.OBSERVABLE_TRANSFORMATION in self.observable_df:
+            if OBSERVABLE_TRANSFORMATION in self.observable_df:
                 trafo = self.observable_df.loc[observable_id,
-                                               petab.OBSERVABLE_TRANSFORMATION]
-                if trafo and trafo != petab.LIN:
+                                               OBSERVABLE_TRANSFORMATION]
+                if trafo and trafo != LIN:
                     raise NotImplementedError(
                         "Observable transformation currently unsupported "
                         "for PySB models")
@@ -287,7 +290,9 @@ def import_model_pysb(
     # PysbPetabProblem
     model_parameters = [p.name for p in pysb_model.parameters]
     for x in petab_problem.condition_df.columns:
-        if x == petab.CONDITION_NAME: continue
+        if x == CONDITION_NAME:
+            continue
+
         if x not in model_parameters:
             raise NotImplementedError(
                 "For PySB PEtab import, only model parameters, but no states "

--- a/python/amici/petab_objective.py
+++ b/python/amici/petab_objective.py
@@ -516,7 +516,7 @@ def create_edata_for_condition(
     # measurements and sigmas
     y, sigma_y = _get_measurements_and_sigmas(
         df_for_condition=measurement_df, timepoints_w_reps=timepoints_w_reps,
-        observable_ids=observable_ids)
+        observable_ids=observable_ids, observable_df=petab_problem.observable_df)
     edata.setObservedData(y.flatten())
     edata.setObservedDataStdDev(sigma_y.flatten())
 
@@ -571,7 +571,9 @@ def _get_timepoints_with_replicates(
 def _get_measurements_and_sigmas(
         df_for_condition: pd.DataFrame,
         timepoints_w_reps: Sequence[numbers.Number],
-        observable_ids: Sequence[str]) -> Tuple[np.array, np.array]:
+        observable_ids: Sequence[str],
+        observable_df: pd.DataFrame,
+    ) -> Tuple[np.array, np.array]:
     """
     Get measurements and sigmas
 
@@ -624,6 +626,10 @@ def _get_measurements_and_sigmas(
                           numbers.Number):
                 sigma_y[time_ix_for_obs_ix[observable_ix],
                         observable_ix] = measurement[NOISE_PARAMETERS]
+            elif isinstance(observable_df.loc[measurement[OBSERVABLE_ID], NOISE_FORMULA],
+                          numbers.Number):
+                sigma_y[time_ix_for_obs_ix[observable_ix],
+                        observable_ix] = observable_df.loc[measurement[OBSERVABLE_ID], NOISE_FORMULA]
     return y, sigma_y
 
 

--- a/python/amici/petab_objective.py
+++ b/python/amici/petab_objective.py
@@ -516,7 +516,7 @@ def create_edata_for_condition(
     # measurements and sigmas
     y, sigma_y = _get_measurements_and_sigmas(
         df_for_condition=measurement_df, timepoints_w_reps=timepoints_w_reps,
-        observable_ids=observable_ids, observable_df=petab_problem.observable_df)
+        observable_ids=observable_ids)
     edata.setObservedData(y.flatten())
     edata.setObservedDataStdDev(sigma_y.flatten())
 
@@ -572,7 +572,6 @@ def _get_measurements_and_sigmas(
         df_for_condition: pd.DataFrame,
         timepoints_w_reps: Sequence[numbers.Number],
         observable_ids: Sequence[str],
-        observable_df: pd.DataFrame,
     ) -> Tuple[np.array, np.array]:
     """
     Get measurements and sigmas
@@ -626,10 +625,6 @@ def _get_measurements_and_sigmas(
                           numbers.Number):
                 sigma_y[time_ix_for_obs_ix[observable_ix],
                         observable_ix] = measurement[NOISE_PARAMETERS]
-            elif isinstance(observable_df.loc[measurement[OBSERVABLE_ID], NOISE_FORMULA],
-                          numbers.Number):
-                sigma_y[time_ix_for_obs_ix[observable_ix],
-                        observable_ix] = observable_df.loc[measurement[OBSERVABLE_ID], NOISE_FORMULA]
     return y, sigma_y
 
 

--- a/python/amici/pysb_import.py
+++ b/python/amici/pysb_import.py
@@ -18,7 +18,6 @@ import numpy as np
 import itertools
 import os
 import sys
-from importlib import import_module
 
 from typing import List, Union, Dict, Tuple, Set, Iterable, Any, Callable
 

--- a/python/amici/pysb_import.py
+++ b/python/amici/pysb_import.py
@@ -58,11 +58,12 @@ def pysb2amici(model: pysb.Model,
         observables
 
     :param sigmas:
-        dict of :class:`pysb.core.Expression` names that should be mapped to sigmas
+        dict of :class:`pysb.core.Expression` names that should be mapped to
+        sigmas
 
     :param constant_parameters:
-        list of :class:`pysb.core.Parameter` names that should be mapped as fixed
-        parameter
+        list of :class:`pysb.core.Parameter` names that should be mapped as
+        fixed parameters
 
     :param verbose: verbosity level for logging, True/False default to
         :attr:`logging.ERROR`/:attr:`logging.DEBUG`
@@ -329,18 +330,23 @@ def _get_sigma_name_and_value(
         name of the observable
 
     :param sigmas:
-        list of names of Expressions that are to be mapped to sigmas
+        dict of :class:`pysb.core.Expression` names that should be mapped to
+        sigmas
 
     :return:
         tuple containing symbolic identifier and formula for the specified
         observable
     """
     if obs_name in sigmas:
-        if sigmas[obs_name] not in pysb_model.expressions:
+        sigma_name = sigmas[obs_name]
+        try:
+            # find corresponding Expression instance
+            sigma_expr = next(x for x in pysb_model.expressions
+                              if x.name == sigma_name)
+        except StopIteration:
             raise ValueError(f'value of sigma {obs_name} is not a '
                              f'valid expression.')
-        sigma_name = pysb_model.expressions[sigmas[obs_name].name].name
-        sigma_value = pysb_model.expressions[sigmas[obs_name].name].expand_expr()
+        sigma_value = sigma_expr.expand_expr()
     else:
         sigma_name = f'sigma_{obs_name}'
         sigma_value = sp.sympify(1.0)

--- a/python/amici/pysb_import.py
+++ b/python/amici/pysb_import.py
@@ -99,7 +99,6 @@ def pysb2amici(model: pysb.Model,
         sigmas = {}
 
     set_log_level(logger, verbose)
-
     ode_model = ode_model_from_pysb_importer(
         model, constant_parameters=constant_parameters,
         observables=observables, sigmas=sigmas,
@@ -341,8 +340,8 @@ def _get_sigma_name_and_value(
         if sigmas[obs_name] not in pysb_model.expressions:
             raise ValueError(f'value of sigma {obs_name} is not a '
                              f'valid expression.')
-        sigma_name = pysb_model.expressions[sigmas[obs_name]].name
-        sigma_value = pysb_model.expressions[sigmas[obs_name]].expand_expr()
+        sigma_name = pysb_model.expressions[sigmas[obs_name].name].name
+        sigma_value = pysb_model.expressions[sigmas[obs_name].name].expand_expr()
     else:
         sigma_name = f'sigma_{obs_name}'
         sigma_value = sp.sympify(1.0)
@@ -1202,6 +1201,13 @@ def pysb_model_from_path(pysb_model_file: str) -> pysb.Model:
     :param pysb_model_file: Full or relative path to the PySB model module
     :return: The pysb Model instance
     """
+    pysb.SelfExporter.cleanup()
+    pysb.SelfExporter.do_export = True
+
+    module_name = os.path.split(os.path.split(pysb_model_file)[-1])
+    if module_name in sys.modules:
+        del sys.modules[module_name]
+
     pysb_model_module_name = \
         os.path.splitext(os.path.split(pysb_model_file)[-1])[0]
     import importlib.util

--- a/python/amici/pysb_import.py
+++ b/python/amici/pysb_import.py
@@ -1196,20 +1196,15 @@ def _get_changed_stoichiometries(
 
 
 def pysb_model_from_path(pysb_model_file: str) -> pysb.Model:
-    """Load a pysb model module and return the Model object
+    """Load a pysb model module and return the :class:`pysb.Model` instance
 
     :param pysb_model_file: Full or relative path to the PySB model module
     :return: The pysb Model instance
     """
-    pysb.SelfExporter.cleanup()
-    pysb.SelfExporter.do_export = True
-
-    module_name = os.path.split(os.path.split(pysb_model_file)[-1])
-    if module_name in sys.modules:
-        del sys.modules[module_name]
 
     pysb_model_module_name = \
         os.path.splitext(os.path.split(pysb_model_file)[-1])[0]
+
     import importlib.util
     spec = importlib.util.spec_from_file_location(
         pysb_model_module_name, pysb_model_file)

--- a/python/sdist/amici/petab_import_pysb.py
+++ b/python/sdist/amici/petab_import_pysb.py
@@ -1,0 +1,1 @@
+../../amici/petab_import_pysb.py

--- a/tests/petab_test_suite/test_petab_suite.py
+++ b/tests/petab_test_suite/test_petab_suite.py
@@ -61,15 +61,13 @@ def _test_case(case, model_type):
     else:
         raise ValueError()
 
-
-
     # compile amici model
     model_output_dir = f'amici_models/model_{case}'
     model = import_petab_problem(
-        problem, model_output_dir=model_output_dir)
+        problem, model_output_dir=model_output_dir,
+        force_compile=True)
 
     # simulate
-    chi2s_match = llhs_match = simulations_match = False
     ret = simulate_petab(problem, model, log_level=logging.DEBUG)
 
     rdatas = ret['rdatas']

--- a/tests/petab_test_suite/test_petab_suite.py
+++ b/tests/petab_test_suite/test_petab_suite.py
@@ -59,7 +59,7 @@ def _test_case(case, model_type):
         yaml_file = os.path.join(case_dir, petabtests.problem_yaml_name(case))
         problem = PysbPetabProblem.from_yaml(yaml_file)
     else:
-        raise ValueError()
+        raise ValueError(f"Unsupported model_type: {model_type}")
 
     # compile amici model
     model_output_dir = f'amici_models/model_{case}'


### PR DESCRIPTION
PEtab so far supports only SBML models. As PySB model import is significantly faster, it is convenient to use those models directly without exporting to SBML first, but still being able to use all PEtab features. Therefore, here comes support for PySB-based PEtab problems in AMICI.

Restrictions:
* only Gaussian noise supported so far (#1176)
* no species or compartments allowed in the condition table (but can be handled via model parameters)

Also fixes:
* `amici.import_model_module` import of different models with the same name
* custom sigma expressions in `amici.pysb_import`